### PR TITLE
feat: support sequence diagrams 🚀

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@
 .env.development.local
 .env.test.local
 .env.production.local
+.vscode
 
 npm-debug.log*
 yarn-debug.log*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- Support Sequence Diagrams [#34](https://github.com/excalidraw/mermaid-to-excalidraw/pull/34).
+
 ## 0.1.1 (2023-09-21)
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,20 +1,32 @@
-## Unreleased
+## 0.1.2 (2023-11-03)
 
-- Support Sequence Diagrams [#34](https://github.com/excalidraw/mermaid-to-excalidraw/pull/34).
+## Library
+
+### Features
+
+- Support Sequence Diagrams [#34](https://github.com/excalidraw/mermaid-to-excalidraw/pull/34) by [@ad1992](https://github.com/ad1992).
+
+## Playground
+
+**_This section lists the updates made to the playground and will not affect the integration._**
+
+### Chore
+
+- Adding an example of Complex Decisions & Subprocesses Charts in playground [#31](https://github.com/excalidraw/mermaid-to-excalidraw/pull/31) by [@DYNAMICMORTAL](https://github.com/DYNAMICMORTAL).
 
 ## 0.1.1 (2023-09-21)
 
 ### Fixes
 
-- Support module resolution nodenext so type module works in host [#30](https://github.com/excalidraw/mermaid-to-excalidraw/pull/30) by [@ad1992](https://github.com/ad1992)
+- Support module resolution nodenext so type module works in host [#30](https://github.com/excalidraw/mermaid-to-excalidraw/pull/30) by [@ad1992](https://github.com/ad1992).
 
 ### Build
 
-- Don't minify build output [#29](https://github.com/excalidraw/mermaid-to-excalidraw/pull/29) by [@ad1992](https://github.com/ad1992)
+- Don't minify build output [#29](https://github.com/excalidraw/mermaid-to-excalidraw/pull/29) by [@ad1992](https://github.com/ad1992).
 
 ### Chore
 
-- use excalidraw v0.16.0 [#28](https://github.com/excalidraw/mermaid-to-excalidraw/pull/28) by [@ad1992](https://github.com/ad1992)
+- use excalidraw v0.16.0 [#28](https://github.com/excalidraw/mermaid-to-excalidraw/pull/28) by [@ad1992](https://github.com/ad1992).
 
 ## 0.1.0 (2023-09-13)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@excalidraw/mermaid-to-excalidraw",
-  "version": "0.1.1-sequence1",
+  "version": "0.1.1-sequence2",
   "description": "Mermaid to Excalidraw Diagrams",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -27,7 +27,7 @@
   "devDependencies": {
     "@babel/core": "7.12.0",
     "@excalidraw/eslint-config": "1.0.3",
-    "@excalidraw/excalidraw": "0.16.1-6920-3a6028b",
+    "@excalidraw/excalidraw": "0.16.1-6920-d3d0bd0",
     "@parcel/transformer-sass": "2.9.1",
     "@types/mermaid": "9.2.0",
     "@types/react": "18.2.14",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@excalidraw/mermaid-to-excalidraw",
-  "version": "0.1.1-sequence3",
+  "version": "0.1.1-sequence5",
   "description": "Mermaid to Excalidraw Diagrams",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@excalidraw/mermaid-to-excalidraw",
-  "version": "0.1.1-sequence2",
+  "version": "0.1.1-sequence3",
   "description": "Mermaid to Excalidraw Diagrams",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@excalidraw/mermaid-to-excalidraw",
-  "version": "0.1.1-sequence5",
+  "version": "0.1.2",
   "description": "Mermaid to Excalidraw Diagrams",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@excalidraw/mermaid-to-excalidraw",
-  "version": "0.1.1",
+  "version": "0.1.1-sequence1",
   "description": "Mermaid to Excalidraw Diagrams",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -27,7 +27,7 @@
   "devDependencies": {
     "@babel/core": "7.12.0",
     "@excalidraw/eslint-config": "1.0.3",
-    "@excalidraw/excalidraw": "0.16.0",
+    "@excalidraw/excalidraw": "0.16.1-6920-3a6028b",
     "@parcel/transformer-sass": "2.9.1",
     "@types/mermaid": "9.2.0",
     "@types/react": "18.2.14",

--- a/playground/index.html
+++ b/playground/index.html
@@ -71,7 +71,7 @@
     ></script>
     <script
       crossorigin
-      src="https://unpkg.com/@excalidraw/excalidraw@0.16.1-6920-3a6028b/dist/excalidraw.development.js"
+      src="https://unpkg.com/@excalidraw/excalidraw@0.16.1-6920-d3d0bd0/dist/excalidraw.development.js"
     ></script>
     <script type="module" src="index.ts"></script>
   </body>

--- a/playground/index.html
+++ b/playground/index.html
@@ -48,10 +48,16 @@
       id="diagram-loading-spinner"
       width="50"
     />
-    <h2>Flowchart</h2>
+    <h2>Flowchart Diagrams</h2>
     <details>
       <summary>Flowchart Examples</summary>
       <div id="flowchart-container"></div>
+    </details>
+
+    <h2>Sequence Diagrams</h2>
+    <details>
+      <summary>Sequence Diagram Examples</summary>
+      <div id="sequence-container"></div>
     </details>
     <h2 style="margin-top: 50px">Unsupported diagrams</h2>
     <details>

--- a/playground/index.html
+++ b/playground/index.html
@@ -9,25 +9,23 @@
   <body>
     <section id="custom-test">
       <h1>Custom Test</h1>
-      <ul>
-        <li>
-          Support only flowchart diagram (the input must started with
-          "flowchart")
-        </li>
-        <li>
-          See supported and unsupported features at
-          <a
-            target="_blank"
-            href="https://github.com/excalidraw/mermaid-to-excalidraw/pull/1#issue-1686226562"
-            >PR's description</a
-          >
-        </li>
-      </ul>
+      Supports only
+      <a target="_blank" href="https://mermaid.js.org/syntax/flowchart.html"
+        >Flowchart</a
+      >
+      and
+      <a
+        target="_blank"
+        href="https://mermaid.js.org/syntax/sequenceDiagram.html"
+      >
+        Sequence </a
+      >diagrams.
       <br />
       <textarea
         id="mermaid-input"
         rows="10"
         cols="50"
+        style="margin-top: 1rem"
         placeholder="Input Mermaid Syntax"
       ></textarea
       ><br />
@@ -59,7 +57,7 @@
     </details>
     <h2 style="margin-top: 50px">Unsupported diagrams</h2>
     <details>
-      <summary>Unsupported Examples</summary>
+      <summary>Unsupported Diagram Examples</summary>
       <div id="unsupported"></div>
     </details>
 

--- a/playground/index.html
+++ b/playground/index.html
@@ -73,7 +73,7 @@
     ></script>
     <script
       crossorigin
-      src="https://unpkg.com/@excalidraw/excalidraw@0.16.0/dist/excalidraw.development.js"
+      src="https://unpkg.com/@excalidraw/excalidraw@0.16.1-6920-3a6028b/dist/excalidraw.development.js"
     ></script>
     <script type="module" src="index.ts"></script>
   </body>

--- a/playground/index.html
+++ b/playground/index.html
@@ -31,8 +31,6 @@
         placeholder="Input Mermaid Syntax"
       ></textarea
       ><br />
-      <label for="font-size-input">Custom Font Size: </label>
-      <input type="number" id="font-size-input" value="20" /><br />
       <button id="render-excalidraw-btn">Render to Excalidraw</button>
       <div id="custom-diagram"></div>
       <details id="parsed-data-details">

--- a/playground/index.html
+++ b/playground/index.html
@@ -48,8 +48,17 @@
       id="diagram-loading-spinner"
       width="50"
     />
-    <div id="flowchart-container"></div>
-    <div id="unsupported"></div>
+    <h2>Flowchart</h2>
+    <details>
+      <summary>Flowchart Examples</summary>
+      <div id="flowchart-container"></div>
+    </details>
+    <h2 style="margin-top: 50px">Unsupported diagrams</h2>
+    <details>
+      <summary>Unsupported Examples</summary>
+      <div id="unsupported"></div>
+    </details>
+
     <script
       crossorigin
       src="https://unpkg.com/react@18/umd/react.development.js"

--- a/playground/index.ts
+++ b/playground/index.ts
@@ -41,13 +41,13 @@ let indexOffset = 0;
       <p>Unsupported diagram will be rendered as SVG image.</p>
     `;
   await Promise.all(
-    UNSUPPORTED_DIAGRAM_TESTCASES.map((diagramDefinition, index) => {
-      const name = `Test ${index + 1}`;
+    UNSUPPORTED_DIAGRAM_TESTCASES.map((testcase, index) => {
+      const { name, defination } = testcase;
 
       return renderDiagram(
         unsupportedContainer,
         name,
-        diagramDefinition,
+        defination,
         index + indexOffset
       );
     })

--- a/playground/index.ts
+++ b/playground/index.ts
@@ -69,10 +69,10 @@ async function renderDiagram(
   </h2>
   
   <pre style="font-size:16px; font-weight:600;font-style:italic;background:#eeeef1;width:40vw;padding:5px" id="mermaid-syntax-${i}"></pre>
-  <div id="diagram-${i}"></div>
 
   <button id="diagram-btn-${i}" data="${i}">Render to Excalidraw</button>
-  
+  <div id="diagram-${i}"></div>
+
   <details style="margin-top: 10px">
     <summary>View Parsed data from parseMermaid</summary>
     <pre style="font-size:16px; background:#eeeef1;width:40vw;padding:5px"  id="parsed-${i}"></pre>

--- a/playground/index.ts
+++ b/playground/index.ts
@@ -71,7 +71,7 @@ async function renderDiagram(
   <pre style="font-size:16px; font-weight:600;font-style:italic;background:#eeeef1;width:40vw;padding:5px" id="mermaid-syntax-${i}"></pre>
 
   <button id="diagram-btn-${i}" data="${i}">Render to Excalidraw</button>
-  <div id="diagram-${i}"></div>
+  <div id="diagram-${i}" style="width:50%"></div>
 
   <details style="margin-top: 10px">
     <summary>View Parsed data from parseMermaid</summary>

--- a/playground/index.ts
+++ b/playground/index.ts
@@ -65,7 +65,7 @@ async function renderDiagram(
 ) {
   const diagramContainerEl = document.createElement("div");
   diagramContainerEl.id = `diagram-container-${i}`;
-  diagramContainerEl.innerHTML = `<h2 style="margin-top: 50px">${name}
+  diagramContainerEl.innerHTML = `<h2 style="margin-top: 50px; color:#f06595;">${name}
   </h2>
   
   <pre style="font-size:16px; font-weight:600;font-style:italic;background:#eeeef1;width:40vw;padding:5px" id="mermaid-syntax-${i}"></pre>
@@ -83,7 +83,6 @@ async function renderDiagram(
   btn.addEventListener("click", async () => {
     const data = btn.getAttribute("data");
     const pd = document.getElementById(`parsed-${data}`)!;
-    console.log(pd.innerHTML, "HEYYY", data);
     renderExcalidraw(pd.innerHTML);
   });
 

--- a/playground/index.ts
+++ b/playground/index.ts
@@ -67,15 +67,15 @@ async function renderDiagram(
   diagramContainerEl.id = `diagram-container-${i}`;
   diagramContainerEl.innerHTML = `<h2 style="margin-top: 50px">${name}
   </h2>
+  
+  <pre style="font-size:16px; font-weight:600;font-style:italic;background:#eeeef1;width:40vw;padding:5px" id="mermaid-syntax-${i}"></pre>
   <div id="diagram-${i}"></div>
+
   <button id="diagram-btn-${i}" data="${i}">Render to Excalidraw</button>
-  <details style="margin-top: 20px">
-    <summary>Mermaid syntax</summary>
-    <pre id="mermaid-syntax-${i}"></pre>
-  </details>
+  
   <details style="margin-top: 10px">
-    <summary>Parsed data from parseMermaid</summary>
-    <pre id="parsed-${i}"></pre>
+    <summary>View Parsed data from parseMermaid</summary>
+    <pre style="font-size:16px; background:#eeeef1;width:40vw;padding:5px"  id="parsed-${i}"></pre>
   </details>`;
 
   const btn = diagramContainerEl.querySelector(`#diagram-btn-${i}`)!;

--- a/playground/index.ts
+++ b/playground/index.ts
@@ -9,28 +9,46 @@ mermaid.initialize({ startOnLoad: false });
 
 import "./initCustomTest";
 import { renderExcalidraw } from "./initExcalidraw.js";
+import { SEQUENCE_DIAGRAM_TESTCASES } from "./testcases/sequence.js";
 
+let indexOffset = 0;
 (async () => {
   // Render flowchart diagrams
   const flowchartContainer = document.getElementById("flowchart-container")!;
   await Promise.all(
-    FLOWCHART_DIAGRAM_TESTCASES.map((diagramDefinition, i) => {
-      return renderDiagram(flowchartContainer, diagramDefinition, i);
+    FLOWCHART_DIAGRAM_TESTCASES.map((defination, index) => {
+      const name = `Test ${index + 1}`;
+      return renderDiagram(flowchartContainer, name, defination, index);
     })
   );
-
+  indexOffset += FLOWCHART_DIAGRAM_TESTCASES.length;
+  // Render Sequence diagrams
+  const sequenceContainer = document.getElementById("sequence-container")!;
+  await Promise.all(
+    SEQUENCE_DIAGRAM_TESTCASES.map(({ name, defination }, index) => {
+      return renderDiagram(
+        sequenceContainer,
+        name,
+        defination,
+        index + indexOffset
+      );
+    })
+  );
+  indexOffset += SEQUENCE_DIAGRAM_TESTCASES.length;
   // Render unsupported diagrams
   const unsupportedContainer = document.getElementById("unsupported")!;
   unsupportedContainer.innerHTML = `
       <p>Unsupported diagram will be rendered as SVG image.</p>
     `;
-  const indexOffset = FLOWCHART_DIAGRAM_TESTCASES.length;
   await Promise.all(
-    UNSUPPORTED_DIAGRAM_TESTCASES.map((diagramDefinition, i) => {
+    UNSUPPORTED_DIAGRAM_TESTCASES.map((diagramDefinition, index) => {
+      const name = `Test ${index + 1}`;
+
       return renderDiagram(
         unsupportedContainer,
+        name,
         diagramDefinition,
-        i + indexOffset
+        index + indexOffset
       );
     })
   );
@@ -41,12 +59,13 @@ import { renderExcalidraw } from "./initExcalidraw.js";
 
 async function renderDiagram(
   containerEl: HTMLElement,
+  name: string,
   diagramDefinition: string,
   i: number
 ) {
   const diagramContainerEl = document.createElement("div");
   diagramContainerEl.id = `diagram-container-${i}`;
-  diagramContainerEl.innerHTML = `<h2 style="margin-top: 50px">Test #${i + 1}
+  diagramContainerEl.innerHTML = `<h2 style="margin-top: 50px">${name}
   </h2>
   <div id="diagram-${i}"></div>
   <button id="diagram-btn-${i}" data="${i}">Render to Excalidraw</button>
@@ -64,6 +83,7 @@ async function renderDiagram(
   btn.addEventListener("click", async () => {
     const data = btn.getAttribute("data");
     const pd = document.getElementById(`parsed-${data}`)!;
+    console.log(pd.innerHTML, "HEYYY", data);
     renderExcalidraw(pd.innerHTML);
   });
 

--- a/playground/index.ts
+++ b/playground/index.ts
@@ -83,7 +83,7 @@ async function renderDiagram(
   btn.addEventListener("click", async () => {
     const data = btn.getAttribute("data");
     const pd = document.getElementById(`parsed-${data}`)!;
-    renderExcalidraw(pd.innerHTML);
+    renderExcalidraw(pd.textContent!);
   });
 
   const diagramEl = diagramContainerEl.querySelector(`#diagram-${i}`)!;
@@ -103,10 +103,7 @@ async function renderDiagram(
 
   // Get parsed data
   try {
-    const data = await parseMermaid(diagramDefinition, {
-      fontSize: DEFAULT_FONT_SIZE,
-    });
-
+    const data = await parseMermaid(diagramDefinition);
     const parsedDataViewerEl = diagramContainerEl.querySelector(
       `#parsed-${i}`
     )!;

--- a/playground/index.ts
+++ b/playground/index.ts
@@ -13,7 +13,6 @@ import { renderExcalidraw } from "./initExcalidraw.js";
 (async () => {
   // Render flowchart diagrams
   const flowchartContainer = document.getElementById("flowchart-container")!;
-  document.body.appendChild(flowchartContainer);
   await Promise.all(
     FLOWCHART_DIAGRAM_TESTCASES.map((diagramDefinition, i) => {
       return renderDiagram(flowchartContainer, diagramDefinition, i);
@@ -23,11 +22,9 @@ import { renderExcalidraw } from "./initExcalidraw.js";
   // Render unsupported diagrams
   const unsupportedContainer = document.getElementById("unsupported")!;
   unsupportedContainer.innerHTML = `
-      <h1 style="margin-top: 50px">Unsupported diagrams</h1>
       <p>Unsupported diagram will be rendered as SVG image.</p>
     `;
   const indexOffset = FLOWCHART_DIAGRAM_TESTCASES.length;
-  document.body.appendChild(unsupportedContainer);
   await Promise.all(
     UNSUPPORTED_DIAGRAM_TESTCASES.map((diagramDefinition, i) => {
       return renderDiagram(

--- a/playground/initCustomTest.ts
+++ b/playground/initCustomTest.ts
@@ -26,9 +26,7 @@ btn.addEventListener("click", async () => {
     diagramEl.innerHTML = svg;
 
     // Parse Mermaid diagram and render to Excalidraw
-    const parsedData = await parseMermaid(diagramDefinition, {
-      fontSize: 20,
-    });
+    const parsedData = await parseMermaid(diagramDefinition);
 
     const parsedDataEl = document.getElementById("custom-parsed-data")!;
     parsedDataEl.parentElement!.style.display = "block";

--- a/playground/initCustomTest.ts
+++ b/playground/initCustomTest.ts
@@ -19,10 +19,7 @@ btn.addEventListener("click", async () => {
 
     // Render Mermaid diagram
     const diagramEl = document.getElementById("custom-diagram")!;
-    const { svg } = await mermaid.render(
-      `custom-digaram`,
-      `%%{init: {"themeVariables": {"fontSize": "20px"}} }%%\n${diagramDefinition}`
-    );
+    const { svg } = await mermaid.render("custom-digaram", diagramDefinition);
     diagramEl.innerHTML = svg;
 
     // Parse Mermaid diagram and render to Excalidraw

--- a/playground/initCustomTest.ts
+++ b/playground/initCustomTest.ts
@@ -14,31 +14,27 @@ btn.addEventListener("click", async () => {
     const mermaidInput = document.getElementById(
       "mermaid-input"
     ) as HTMLInputElement;
-    const fontSizeInput = document.getElementById(
-      "font-size-input"
-    ) as HTMLInputElement;
 
     const diagramDefinition = mermaidInput.value;
-    const customFontSize = Number(fontSizeInput.value);
 
     // Render Mermaid diagram
     const diagramEl = document.getElementById("custom-diagram")!;
     const { svg } = await mermaid.render(
       `custom-digaram`,
-      `%%{init: {"themeVariables": {"fontSize": "${customFontSize}px"}} }%%\n${diagramDefinition}`
+      `%%{init: {"themeVariables": {"fontSize": "20px"}} }%%\n${diagramDefinition}`
     );
     diagramEl.innerHTML = svg;
 
     // Parse Mermaid diagram and render to Excalidraw
     const parsedData = await parseMermaid(diagramDefinition, {
-      fontSize: customFontSize,
+      fontSize: 20,
     });
 
     const parsedDataEl = document.getElementById("custom-parsed-data")!;
     parsedDataEl.parentElement!.style.display = "block";
     parsedDataEl.innerText = JSON.stringify(parsedData, null, 2);
 
-    renderExcalidraw(JSON.stringify(parsedData), customFontSize);
+    renderExcalidraw(JSON.stringify(parsedData));
   } catch (e) {
     errorEl.setAttribute("style", "display: block");
     errorEl.innerHTML = String(e);

--- a/playground/style.scss
+++ b/playground/style.scss
@@ -55,3 +55,9 @@ button {
     margin-top: 20px;
   }
 }
+
+a {
+  color: #0071ce;
+  font-weight: 600;
+  text-decoration: none;
+}

--- a/playground/style.scss
+++ b/playground/style.scss
@@ -6,7 +6,16 @@ body {
     max-width: 48%;
   }
 }
-
+button {
+  height: 40px;
+  font-size: 16px;
+  background: #4dabf7;
+  border: 1px solid #a5d8ff;
+  box-shadow: none;
+  border-radius: 2px;
+  color: white;
+  cursor: pointer;
+}
 #excalidraw {
   width: 50vw;
   height: 100vh;

--- a/playground/testcases/sequence.ts
+++ b/playground/testcases/sequence.ts
@@ -80,6 +80,18 @@ const SEQUENCE_DIAGRAM_TESTCASES = [
     end`,
   },
   {
+    name: "Critical Regions",
+    defination: `
+  sequenceDiagram
+    critical Establish a connection to the DB
+        Service-->DB: connect
+    option Network timeout
+        Service-->Service: Log error
+    option Credentials rejected
+        Service-->Service: Log different error
+    end`,
+  },
+  {
     name: "Parallel Actions",
     defination: `sequenceDiagram
     par Alice to Bob

--- a/playground/testcases/sequence.ts
+++ b/playground/testcases/sequence.ts
@@ -90,6 +90,17 @@ const SEQUENCE_DIAGRAM_TESTCASES = [
     Bob-->>Alice: Hi Alice!
     John-->>Alice: Hi Alice!`,
   },
+  {
+    name: "Break",
+    defination: `
+sequenceDiagram
+    Consumer-->API: Book something
+    API-->BookingService: Start booking process
+    break when the booking process fails
+        API-->Consumer: show failure
+    end
+    API-->BillingService: Start billing process`,
+  },
 ];
 
 export { SEQUENCE_DIAGRAM_TESTCASES };

--- a/playground/testcases/sequence.ts
+++ b/playground/testcases/sequence.ts
@@ -1,0 +1,32 @@
+const SEQUENCE_DIAGRAM_TESTCASES = [
+  {
+    name: "Solid and dotted line without arrow",
+    defination: `sequenceDiagram
+  Alice->John: Hello John, how are you?
+  John-->Alice: Great!
+  Alice->John: See you later!`,
+  },
+  {
+    name: "Solid and dotted line with arrow head",
+    defination: `sequenceDiagram
+  Alice->>John: Hello John, how are you?
+  John-->>Alice: Great!
+  Alice->>John: See you later!`,
+  },
+  {
+    name: "Solid and Dotted line with cross at end",
+    defination: `sequenceDiagram
+  Alice-xJohn: Hello John, how are you?
+  John--xAlice: Great!
+  Alice-xJohn: See you later!`,
+  },
+  {
+    name: "Solid and dotted line with open arrow at end",
+    defination: `sequenceDiagram
+  Alice-)John: Hello John, how are you?
+  John--)Alice: Great!
+  Alice-)John: See you later!`,
+  },
+];
+
+export { SEQUENCE_DIAGRAM_TESTCASES };

--- a/playground/testcases/sequence.ts
+++ b/playground/testcases/sequence.ts
@@ -35,6 +35,14 @@ const SEQUENCE_DIAGRAM_TESTCASES = [
     Alice->>Bob: Hi Bob
     Bob->>Alice: Hi Alice`,
   },
+  {
+    name: "Identifiers",
+    defination: `sequenceDiagram
+    participant A as Alice
+    participant J as John
+    A->>J: Hello John, how are you?
+    J->>A: Great!`,
+  },
 ];
 
 export { SEQUENCE_DIAGRAM_TESTCASES };

--- a/playground/testcases/sequence.ts
+++ b/playground/testcases/sequence.ts
@@ -157,6 +157,15 @@ sequenceDiagram
   Alice ->>+ John: Did you want to go to the game tonight?
   John -->>- Alice: Yeah! See you there.`,
   },
+  {
+    name: "Sequence Numbers",
+    defination: `sequenceDiagram
+    autonumber
+    Alice->>John: Hello John, how are you?
+    John-->>Alice: Great!
+    John->>Bob: How about you?
+    Bob-->>John: Jolly good!`,
+  },
 ];
 
 export { SEQUENCE_DIAGRAM_TESTCASES };

--- a/playground/testcases/sequence.ts
+++ b/playground/testcases/sequence.ts
@@ -101,6 +101,14 @@ sequenceDiagram
     end
     API-->BillingService: Start billing process`,
   },
+  {
+    name: "Comments",
+    defination: `
+    sequenceDiagram
+    Alice->>John: Hi John, whats up?
+    %% this is a comment
+    John-->>Alice: Great!`,
+  },
 ];
 
 export { SEQUENCE_DIAGRAM_TESTCASES };

--- a/playground/testcases/sequence.ts
+++ b/playground/testcases/sequence.ts
@@ -79,6 +79,17 @@ const SEQUENCE_DIAGRAM_TESTCASES = [
         Bob->>Alice: Thanks for asking
     end`,
   },
+  {
+    name: "Parallel Actions",
+    defination: `sequenceDiagram
+    par Alice to Bob
+        Alice->>Bob: Hello Folks!
+    and Alice to John
+        Alice->>John: Hello Folks!
+    end
+    Bob-->>Alice: Hi Alice!
+    John-->>Alice: Hi Alice!`,
+  },
 ];
 
 export { SEQUENCE_DIAGRAM_TESTCASES };

--- a/playground/testcases/sequence.ts
+++ b/playground/testcases/sequence.ts
@@ -3,8 +3,7 @@ const SEQUENCE_DIAGRAM_TESTCASES = [
     name: "Solid and dotted line without arrow",
     defination: `sequenceDiagram
   Alice->John: Hello John, how are you?
-  John-->Alice: Great!
-  Alice->John: See you later!`,
+  John-->Alice: Great!`,
   },
   {
     name: "Solid and dotted line with arrow head",
@@ -17,8 +16,7 @@ const SEQUENCE_DIAGRAM_TESTCASES = [
     name: "Solid and Dotted line with cross at end",
     defination: `sequenceDiagram
   Alice-xJohn: Hello John, how are you?
-  John--xAlice: Great!
-  Alice-xJohn: See you later!`,
+  John--xAlice: Great!`,
   },
   {
     name: "Solid and dotted line with open arrow at end",
@@ -36,7 +34,7 @@ const SEQUENCE_DIAGRAM_TESTCASES = [
     Bob->>Alice: Hi Alice`,
   },
   {
-    name: "Identifiers",
+    name: "Aliases",
     defination: `sequenceDiagram
     participant A as Alice
     participant J as John
@@ -49,6 +47,14 @@ const SEQUENCE_DIAGRAM_TESTCASES = [
     participant Alice
     Note left of Alice: This is a note
     Note right of Alice: Hey I am coming soon!`,
+  },
+  {
+    name: "Activations",
+    defination: `sequenceDiagram
+    Alice->>+John: Hello John, how are you?
+    Alice->>+John: John, can you hear me?
+    John-->>-Alice: Hi Alice, I can hear you!
+    John-->>-Alice: I feel great!`,
   },
 ];
 

--- a/playground/testcases/sequence.ts
+++ b/playground/testcases/sequence.ts
@@ -49,6 +49,23 @@ const SEQUENCE_DIAGRAM_TESTCASES = [
     Note right of Alice: Hey I am coming soon!`,
   },
   {
+    name: "Grouping",
+    defination: `
+    sequenceDiagram
+    box rgb(191, 223, 255) Alice & John
+    participant Alice
+    participant John
+    end
+    box Another Group
+    participant Bob
+    participant June
+    end
+    Alice->>John: Hello John, how are you?
+    John->>Alice: Great!
+    Alice->>Bob: Hello Bob, how is June?
+    Bob->>June: Hello June, how are you?`,
+  },
+  {
     name: "Activations",
     defination: `sequenceDiagram
     Alice->>+John: Hello John, how are you?

--- a/playground/testcases/sequence.ts
+++ b/playground/testcases/sequence.ts
@@ -121,6 +121,25 @@ sequenceDiagram
     %% this is a comment
     John-->>Alice: Great!`,
   },
+  {
+    name: "Background Hightlights",
+    defination: `
+    sequenceDiagram
+  participant Alice
+  participant John
+
+  rect rgb(191, 223, 255)
+  note right of Alice: Alice calls John.
+  Alice->>+John: Hello John, how are you?
+  rect rgb(200, 150, 255)
+  Alice->>+John: John, can you hear me?
+  John-->>-Alice: Hi Alice, I can hear you!
+  end
+  John-->>-Alice: I feel great!
+  end
+  Alice ->>+ John: Did you want to go to the game tonight?
+  John -->>- Alice: Yeah! See you there.`,
+  },
 ];
 
 export { SEQUENCE_DIAGRAM_TESTCASES };

--- a/playground/testcases/sequence.ts
+++ b/playground/testcases/sequence.ts
@@ -173,6 +173,12 @@ const SEQUENCE_DIAGRAM_TESTCASES = [
   John->>Bob: How about you?
   Bob-->>John: Jolly good!`,
   },
+  {
+    name: "Entity codes",
+    defination: `sequenceDiagram
+    Alice->>Bob: I #9829; you!
+    Bob->>Alice: I #9829; you #infin; times more!`,
+  },
 ];
 
 export { SEQUENCE_DIAGRAM_TESTCASES };

--- a/playground/testcases/sequence.ts
+++ b/playground/testcases/sequence.ts
@@ -56,6 +56,15 @@ const SEQUENCE_DIAGRAM_TESTCASES = [
     John-->>-Alice: Hi Alice, I can hear you!
     John-->>-Alice: I feel great!`,
   },
+  {
+    name: "Loops",
+    defination: `
+    sequenceDiagram
+    Alice->John: Hi John, how are you?
+    loop Every minute
+        John-->Alice: Great!
+    end`,
+  },
 ];
 
 export { SEQUENCE_DIAGRAM_TESTCASES };

--- a/playground/testcases/sequence.ts
+++ b/playground/testcases/sequence.ts
@@ -43,6 +43,13 @@ const SEQUENCE_DIAGRAM_TESTCASES = [
     A->>J: Hello John, how are you?
     J->>A: Great!`,
   },
+  {
+    name: "Notes",
+    defination: `sequenceDiagram
+    participant Alice
+    Note left of Alice: This is a note
+    Note right of Alice: Hey I am coming soon!`,
+  },
 ];
 
 export { SEQUENCE_DIAGRAM_TESTCASES };

--- a/playground/testcases/sequence.ts
+++ b/playground/testcases/sequence.ts
@@ -27,6 +27,14 @@ const SEQUENCE_DIAGRAM_TESTCASES = [
   John--)Alice: Great!
   Alice-)John: See you later!`,
   },
+  {
+    name: "Actor symbols",
+    defination: `sequenceDiagram
+    actor Alice
+    actor Bob
+    Alice->>Bob: Hi Bob
+    Bob->>Alice: Hi Alice`,
+  },
 ];
 
 export { SEQUENCE_DIAGRAM_TESTCASES };

--- a/playground/testcases/sequence.ts
+++ b/playground/testcases/sequence.ts
@@ -57,8 +57,8 @@ const SEQUENCE_DIAGRAM_TESTCASES = [
     participant John
     end
     box Another Group
-    participant Bob
-    participant June
+    actor Bob
+    actor June
     end
     Alice->>John: Hello John, how are you?
     John->>Alice: Great!
@@ -156,6 +156,20 @@ sequenceDiagram
   end
   Alice ->>+ John: Did you want to go to the game tonight?
   John -->>- Alice: Yeah! See you there.`,
+  },
+  {
+    name: "Grouping with Background Highlights",
+    defination: `sequenceDiagram
+    rect rgb(191, 223, 255)
+    box rgb(252, 194, 215) Alice and John
+      participant Alice
+      actor John
+    end
+    note right of Alice: Alice calls John.
+    Alice->>+John: Hello John, how are you?
+    John-->>-Alice: I feel great!
+    end
+   `,
   },
   {
     name: "Sequence Numbers",

--- a/playground/testcases/sequence.ts
+++ b/playground/testcases/sequence.ts
@@ -65,6 +65,20 @@ const SEQUENCE_DIAGRAM_TESTCASES = [
         John-->Alice: Great!
     end`,
   },
+  {
+    name: "Alternate Paths",
+    defination: `
+    sequenceDiagram
+    Alice->>Bob: Hello Bob, how are you?
+    alt is sick
+        Bob->>Alice: Not so good :(
+    else is well
+        Bob->>Alice: Feeling fresh like a daisy
+    end
+    opt Extra response
+        Bob->>Alice: Thanks for asking
+    end`,
+  },
 ];
 
 export { SEQUENCE_DIAGRAM_TESTCASES };

--- a/playground/testcases/sequence.ts
+++ b/playground/testcases/sequence.ts
@@ -28,120 +28,113 @@ const SEQUENCE_DIAGRAM_TESTCASES = [
   {
     name: "Actor symbols",
     defination: `sequenceDiagram
-    actor Alice
-    actor Bob
-    Alice->>Bob: Hi Bob
-    Bob->>Alice: Hi Alice`,
+  actor Alice
+  actor Bob
+  Alice->>Bob: Hi Bob
+  Bob->>Alice: Hi Alice`,
   },
   {
     name: "Aliases",
     defination: `sequenceDiagram
-    participant A as Alice
-    participant J as John
-    A->>J: Hello John, how are you?
-    J->>A: Great!`,
+  participant A as Alice
+  participant J as John
+  A->>J: Hello John, how are you?
+  J->>A: Great!`,
   },
   {
     name: "Notes",
     defination: `sequenceDiagram
-    participant Alice
-    Note left of Alice: This is a note
-    Note right of Alice: Hey I am coming soon!`,
+  participant Alice
+  Note left of Alice: This is a note
+  Note right of Alice: Hey I am coming soon!`,
   },
   {
     name: "Grouping",
-    defination: `
-    sequenceDiagram
-    box rgb(191, 223, 255) Alice & John
+    defination: `sequenceDiagram
+  box rgb(191, 223, 255) Alice & John
     participant Alice
     participant John
-    end
-    box Another Group
+  end
+  box Another Group
     actor Bob
     actor June
-    end
-    Alice->>John: Hello John, how are you?
-    John->>Alice: Great!
-    Alice->>Bob: Hello Bob, how is June?
-    Bob->>June: Hello June, how are you?`,
+  end
+  Alice->>John: Hello John, how are you?
+  John->>Alice: Great!
+  Alice->>Bob: Hello Bob, how is June?
+  Bob->>June: Hello June, how are you?`,
   },
   {
     name: "Activations",
     defination: `sequenceDiagram
-    Alice->>+John: Hello John, how are you?
-    Alice->>+John: John, can you hear me?
-    John-->>-Alice: Hi Alice, I can hear you!
-    John-->>-Alice: I feel great!`,
+  Alice->>+John: Hello John, how are you?
+  Alice->>+John: John, can you hear me?
+  John-->>-Alice: Hi Alice, I can hear you!
+  John-->>-Alice: I feel great!`,
   },
   {
     name: "Loops",
-    defination: `
-    sequenceDiagram
-    Alice->John: Hi John, how are you?
-    loop Every minute
-        John-->Alice: Great!
-    end`,
+    defination: `sequenceDiagram
+  Alice->John: Hi John, how are you?
+  loop Every minute
+    John-->Alice: Great!
+  end`,
   },
   {
     name: "Alternate Paths",
-    defination: `
-    sequenceDiagram
-    Alice->>Bob: Hello Bob, how are you?
-    alt is sick
-        Bob->>Alice: Not so good :(
-    else is well
-        Bob->>Alice: Feeling fresh like a daisy
-    end
-    opt Extra response
-        Bob->>Alice: Thanks for asking
-    end`,
+    defination: `sequenceDiagram
+  Alice->>Bob: Hello Bob, how are you?
+  alt is sick
+      Bob->>Alice: Not so good :(
+  else is well
+      Bob->>Alice: Feeling fresh like a daisy
+  end
+  opt Extra response
+      Bob->>Alice: Thanks for asking
+  end`,
   },
   {
     name: "Critical Regions",
-    defination: `
-  sequenceDiagram
-    critical Establish a connection to the DB
-        Service-->DB: connect
-    option Network timeout
-        Service-->Service: Log error
-    option Credentials rejected
-        Service-->Service: Log different error
-    end`,
+    defination: `sequenceDiagram
+  critical Establish a connection to the DB
+      Service-->DB: connect
+  option Network timeout
+      Service-->Service: Log error
+  option Credentials rejected
+      Service-->Service: Log different error
+  end`,
   },
   {
     name: "Parallel Actions",
     defination: `sequenceDiagram
-    par Alice to Bob
-        Alice->>Bob: Hello Folks!
-    and Alice to John
-        Alice->>John: Hello Folks!
-    end
-    Bob-->>Alice: Hi Alice!
-    John-->>Alice: Hi Alice!`,
+  par Alice to Bob
+    Alice->>Bob: Hello Folks!
+  and Alice to John
+    Alice->>John: Hello Folks!
+  end
+  Bob-->>Alice: Hi Alice!
+  John-->>Alice: Hi Alice!`,
   },
   {
     name: "Break",
-    defination: `
-sequenceDiagram
-    Consumer-->API: Book something
-    API-->BookingService: Start booking process
-    break when the booking process fails
-        API-->Consumer: show failure
-    end
-    API-->BillingService: Start billing process`,
+    defination: `sequenceDiagram
+  Consumer-->API: Book something
+  API-->BookingService: Start booking process
+  break when the booking process fails
+      API-->Consumer: show failure
+  end
+  API-->BillingService: Start billing process`,
   },
   {
     name: "Comments",
-    defination: `
-    sequenceDiagram
-    Alice->>John: Hi John, whats up?
-    %% this is a comment
-    John-->>Alice: Great!`,
+    defination: `sequenceDiagram
+  Alice->>John: Hi John, whats up?
+  %% this is a comment
+  John-->>Alice: Great!`,
   },
   {
     name: "Background Hightlights",
-    defination: `
-    sequenceDiagram
+    defination: `sequenceDiagram
   participant Alice
   participant John
 
@@ -160,25 +153,25 @@ sequenceDiagram
   {
     name: "Grouping with Background Highlights",
     defination: `sequenceDiagram
-    rect rgb(191, 223, 255)
-    box rgb(252, 194, 215) Alice and John
-      participant Alice
-      actor John
-    end
-    note right of Alice: Alice calls John.
-    Alice->>+John: Hello John, how are you?
-    John-->>-Alice: I feel great!
-    end
+  rect rgb(191, 223, 255)
+  box rgb(252, 194, 215) Alice and John
+    participant Alice
+    actor John
+  end
+  note right of Alice: Alice calls John.
+  Alice->>+John: Hello John, how are you?
+  John-->>-Alice: I feel great!
+  end
    `,
   },
   {
     name: "Sequence Numbers",
     defination: `sequenceDiagram
-    autonumber
-    Alice->>John: Hello John, how are you?
-    John-->>Alice: Great!
-    John->>Bob: How about you?
-    Bob-->>John: Jolly good!`,
+  autonumber
+  Alice->>John: Hello John, how are you?
+  John-->>Alice: Great!
+  John->>Bob: How about you?
+  Bob-->>John: Jolly good!`,
   },
 ];
 

--- a/playground/testcases/unsupported.ts
+++ b/playground/testcases/unsupported.ts
@@ -1,9 +1,14 @@
 export default [
-  `erDiagram
+  {
+    name: "ER Diagram",
+    defination: `erDiagram
     CUSTOMER ||--o{ ORDER : places
     ORDER ||--|{ LINE-ITEM : contains
     CUSTOMER }|..|{ DELIVERY-ADDRESS : uses`,
-  `gantt
+  },
+  {
+    name: "Gantt Diagram",
+    defination: `gantt
     title A Gantt Diagram
     dateFormat  YYYY-MM-DD
     section Section
@@ -12,4 +17,5 @@ export default [
     section Another
     Task in sec      :2014-01-12  , 12d
     another task      : 24d`,
+  },
 ];

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,5 +1,4 @@
 export const DEFAULT_FONT_SIZE = 20;
-export const SUPPORTED_DIAGRAM_TYPES = ["flowchart", "sequenceDiagram"];
 
 export const SVG_TO_SHAPE_MAPPER: { [key: string]: "rectangle" | "ellipse" } = {
   rect: "rectangle",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,2 +1,2 @@
 export const DEFAULT_FONT_SIZE = 20;
-export const SUPPORTED_DIAGRAM_TYPES = ["flowchart"];
+export const SUPPORTED_DIAGRAM_TYPES = ["flowchart", "sequenceDiagram"];

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,2 +1,9 @@
 export const DEFAULT_FONT_SIZE = 20;
 export const SUPPORTED_DIAGRAM_TYPES = ["flowchart", "sequenceDiagram"];
+
+export const SVG_TO_SHAPE_MAPPER: { [key: string]: string } = {
+  rect: "rectangle",
+  circle: "ellipse",
+  text: "text",
+  line: "line",
+};

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,9 +1,7 @@
 export const DEFAULT_FONT_SIZE = 20;
 export const SUPPORTED_DIAGRAM_TYPES = ["flowchart", "sequenceDiagram"];
 
-export const SVG_TO_SHAPE_MAPPER: { [key: string]: string } = {
+export const SVG_TO_SHAPE_MAPPER: { [key: string]: "rectangle" | "ellipse" } = {
   rect: "rectangle",
   circle: "ellipse",
-  text: "text",
-  line: "line",
 };

--- a/src/converter/GraphConverter.ts
+++ b/src/converter/GraphConverter.ts
@@ -1,8 +1,10 @@
 import { MermaidOptions } from "../index.js";
 import { DEFAULT_FONT_SIZE } from "../constants.js";
-import { Graph, MermaidToExcalidrawResult } from "../interfaces.js";
+import { MermaidToExcalidrawResult } from "../interfaces.js";
+import { Flowchart } from "../parser/flowchart.js";
+import { Sequence } from "../parser/sequence.js";
 
-export class GraphConverter<T = Graph> {
+export class GraphConverter<T = Flowchart | Sequence> {
   private converter;
   constructor({
     converter,

--- a/src/converter/helpers.ts
+++ b/src/converter/helpers.ts
@@ -82,7 +82,7 @@ export const computeGroupIds = (
   };
 };
 
-interface ArrowType {
+export interface ArrowType {
   startArrowhead?: Arrowhead;
   endArrowhead?: Arrowhead;
 }

--- a/src/converter/helpers.ts
+++ b/src/converter/helpers.ts
@@ -4,8 +4,6 @@ import {
 } from "@excalidraw/excalidraw/types/element/types.js";
 import {
   CONTAINER_STYLE_PROPERTY,
-  Edge,
-  Graph,
   LABEL_STYLE_PROPERTY,
   SubGraph,
   Vertex,
@@ -13,75 +11,11 @@ import {
 import { ExcalidrawVertexElement } from "../types.js";
 import { Mutable } from "@excalidraw/excalidraw/types/utility-types.js";
 import { removeMarkdown } from "@excalidraw/markdown-to-text";
+import { Edge } from "../parser/flowchart.js";
 
 /**
  * Compute groupIds for each element
  */
-export const computeGroupIds = (
-  graph: Graph
-): {
-  getGroupIds: (elementId: string) => string[];
-  getParentId: (elementId: string) => string | null;
-} => {
-  // Parse the diagram into a tree for rendering and grouping
-  const tree: {
-    [key: string]: {
-      id: string;
-      parent: string | null;
-      isLeaf: boolean; // true = vertex, false = subGraph
-    };
-  } = {};
-  graph.subGraphs.map((subGraph) => {
-    subGraph.nodeIds.forEach((nodeId) => {
-      tree[subGraph.id] = {
-        id: subGraph.id,
-        parent: null,
-        isLeaf: false,
-      };
-      tree[nodeId] = {
-        id: nodeId,
-        parent: subGraph.id,
-        isLeaf: graph.vertices[nodeId] !== undefined,
-      };
-    });
-  });
-  const mapper: {
-    [key: string]: string[];
-  } = {};
-  [...Object.keys(graph.vertices), ...graph.subGraphs.map((c) => c.id)].forEach(
-    (id) => {
-      if (!tree[id]) {
-        return;
-      }
-      let curr = tree[id];
-      const groupIds: string[] = [];
-      if (!curr.isLeaf) {
-        groupIds.push(`subgraph_group_${curr.id}`);
-      }
-
-      while (true) {
-        if (curr.parent) {
-          groupIds.push(`subgraph_group_${curr.parent}`);
-          curr = tree[curr.parent];
-        } else {
-          break;
-        }
-      }
-
-      mapper[id] = groupIds;
-    }
-  );
-
-  return {
-    getGroupIds: (elementId) => {
-      return mapper[elementId] || [];
-    },
-    getParentId: (elementId) => {
-      return tree[elementId] ? tree[elementId].parent : null;
-    },
-  };
-};
-
 export interface ArrowType {
   startArrowhead?: Arrowhead;
   endArrowhead?: Arrowhead;

--- a/src/converter/types/flowchart.ts
+++ b/src/converter/types/flowchart.ts
@@ -9,9 +9,10 @@ import {
   computeExcalidrawArrowType,
 } from "../helpers.js";
 import { VERTEX_TYPE } from "../../interfaces.js";
+import { Flowchart } from "../../parser/flowchart.js";
 
 export const FlowchartToExcalidrawSkeletonConverter = new GraphConverter({
-  converter: (graph, options) => {
+  converter: (graph: Flowchart, options) => {
     const elements: ExcalidrawElementSkeleton[] = [];
     const fontSize = options.fontSize;
     const { getGroupIds, getParentId } = computeGroupIds(graph);

--- a/src/converter/types/sequence.ts
+++ b/src/converter/types/sequence.ts
@@ -27,6 +27,9 @@ const createLine = (line: Line) => {
     ],
     width: line.endX - line.startX,
     height: line.endY - line.startY,
+    strokeStyle: line.strokeStyle || "solid",
+    strokeColor: line.strokeColor || "#000",
+    strokeWidth: line.strokeWidth || 1,
   };
   return lineElement;
 };
@@ -149,6 +152,16 @@ export const SequenceToExcalidrawSkeletonConvertor = new GraphConverter({
       elements.push(createArrow(arrow));
     });
     elements.push(...activations);
+
+    // loops
+    const { lines, texts } = chart.loops;
+    lines.forEach((line) => {
+      elements.push(createLine(line));
+    });
+    texts.forEach((text) => {
+      elements.push(createText(text));
+    });
+
     return { elements };
   },
 });

--- a/src/converter/types/sequence.ts
+++ b/src/converter/types/sequence.ts
@@ -1,0 +1,83 @@
+import { ExcalidrawElementSkeleton } from "@excalidraw/excalidraw/types/data/transform.js";
+import { GraphConverter } from "../GraphConverter.js";
+import { StrokeStyle } from "@excalidraw/excalidraw/types/element/types.js";
+import { Sequence } from "../../parser/sequence.js";
+
+// Arrow mapper for the supported sequence arrow types
+const EXCALIDRAW_STROKE_STYLE_FOR_ARROW: { [key: string]: StrokeStyle } = {
+  SOLID: "solid",
+  DOTTED: "dotted",
+  SOLID_CROSS: "solid",
+  DOTTED_CROSS: "dotted",
+  DOTTED_OPEN: "dotted",
+  SOLID_POINT: "solid",
+  DOTTED_POINT: "dotted",
+};
+export const SequenceToExcalidrawSkeletonConvertor = new GraphConverter({
+  converter: (chart: Sequence, options: any) => {
+    const elements: ExcalidrawElementSkeleton[] = [];
+    const fontSize = options.fontSize;
+    console.log(chart, "CHART");
+    Object.values(chart.nodes).forEach((vertex) => {
+      if (!vertex) {
+        return;
+      }
+      const container: ExcalidrawElementSkeleton = {
+        type: "rectangle",
+        x: vertex.x,
+        y: vertex.y,
+        width: vertex.width,
+        height: vertex.height,
+        label: {
+          text: vertex.text,
+          fontSize,
+          verticalAlign: "middle",
+        },
+      };
+      elements.push(container);
+    });
+
+    Object.values(chart.lines).forEach((line) => {
+      if (!line) {
+        return;
+      }
+      const lineElement: ExcalidrawElementSkeleton = {
+        type: "line",
+        x: line.startX,
+        y: line.startY,
+        points: [
+          [0, 0],
+          [line.endX - line.startX, line.endY - line.startY],
+        ],
+        width: line.endX - line.startX,
+        height: line.endY - line.startY,
+      };
+      elements.push(lineElement);
+    });
+
+    Object.values(chart.arrows).forEach((arrow) => {
+      if (!arrow) {
+        return;
+      }
+      const arrowElement: ExcalidrawElementSkeleton = {
+        type: "arrow",
+        x: arrow.startX,
+        y: arrow.startY,
+        points: [
+          [0, 0],
+          [arrow.endX - arrow.startX, arrow.endY - arrow.startY],
+        ],
+        width: arrow.endX - arrow.startX,
+        height: arrow.endY - arrow.startY,
+        strokeStyle: EXCALIDRAW_STROKE_STYLE_FOR_ARROW[arrow.arrowType],
+
+        label: {
+          text: arrow.text || "",
+        },
+      };
+      elements.push(arrowElement);
+    });
+    console.log(elements, "ELEMENTS");
+    return { elements };
+  },
+});

--- a/src/converter/types/sequence.ts
+++ b/src/converter/types/sequence.ts
@@ -57,6 +57,8 @@ const createContainer = (element: Exclude<Node, Line | Arrow | Text>) => {
       fontSize: element?.label?.fontSize,
       verticalAlign: "middle",
     },
+    strokeStyle: element?.strokeStyle,
+    strokeWidth: element?.strokeWidth,
   };
   return container;
 };

--- a/src/converter/types/sequence.ts
+++ b/src/converter/types/sequence.ts
@@ -1,7 +1,13 @@
 import { ExcalidrawElementSkeleton } from "@excalidraw/excalidraw/types/data/transform.js";
 import { GraphConverter } from "../GraphConverter.js";
-import { StrokeStyle } from "@excalidraw/excalidraw/types/element/types.js";
-import { Sequence } from "../../parser/sequence.js";
+import {
+  ExcalidrawRectangleElement,
+  ExcalidrawTextElement,
+  StrokeStyle,
+} from "@excalidraw/excalidraw/types/element/types.js";
+import { Arrow, Line, Node, Sequence } from "../../parser/sequence.js";
+import { ExcalidrawElement } from "../../types.js";
+import { MermaidOptions } from "../../index.js";
 
 // Arrow mapper for the supported sequence arrow types
 const EXCALIDRAW_STROKE_STYLE_FOR_ARROW: { [key: string]: StrokeStyle } = {
@@ -14,75 +20,123 @@ const EXCALIDRAW_STROKE_STYLE_FOR_ARROW: { [key: string]: StrokeStyle } = {
   SOLID_POINT: "solid",
   DOTTED_POINT: "dotted",
 };
+
+const createLine = (line: Line) => {
+  console.log(line, "LINE");
+  const lineElement: ExcalidrawElementSkeleton = {
+    type: "line",
+    x: line.startX,
+    y: line.startY,
+    points: [
+      [0, 0],
+      [line.endX - line.startX, line.endY - line.startY],
+    ],
+    width: line.endX - line.startX,
+    height: line.endY - line.startY,
+  };
+  console.log(lineElement);
+  return lineElement;
+};
+
+const createText = (element: Node) => {
+  const textElement: ExcalidrawElementSkeleton = {
+    type: "text",
+    x: element.x,
+    y: element.y,
+    width: element.width,
+    height: element.height,
+    text: element.text || "",
+    fontSize: element.fontSize,
+    verticalAlign: "middle",
+  };
+  return textElement;
+};
+
+const createContainer = (element: Node, options: MermaidOptions) => {
+  const container: ExcalidrawElementSkeleton = {
+    type: element.type,
+    x: element.x,
+    y: element.y,
+    width: element.width,
+    height: element.height,
+    label: {
+      text: element.text || "",
+      fontSize: options.fontSize,
+      verticalAlign: "middle",
+    },
+  };
+  return container;
+};
+
+const createArrow = (arrow: Arrow) => {
+  const strokeStyle = EXCALIDRAW_STROKE_STYLE_FOR_ARROW[arrow.strokeStyle];
+  const arrowElement: ExcalidrawElementSkeleton = {
+    type: "arrow",
+    x: arrow.startX,
+    y: arrow.startY,
+    points: [
+      [0, 0],
+      [arrow.endX - arrow.startX, arrow.endY - arrow.startY],
+    ],
+    width: arrow.endX - arrow.startX,
+    height: arrow.endY - arrow.startY,
+    strokeStyle,
+    endArrowhead:
+      arrow.strokeStyle === "SOLID_OPEN" || arrow.strokeStyle === "DOTTED_OPEN"
+        ? null
+        : "arrow",
+    label: {
+      text: arrow.text || "",
+    },
+  };
+  return arrowElement;
+};
 export const SequenceToExcalidrawSkeletonConvertor = new GraphConverter({
   converter: (chart: Sequence, options: any) => {
     const elements: ExcalidrawElementSkeleton[] = [];
-    const fontSize = options.fontSize;
-    Object.values(chart.nodes).forEach((vertex) => {
-      if (!vertex) {
+    Object.values(chart.nodes).forEach((node) => {
+      if (!node || !node.length) {
         return;
       }
-      const container: ExcalidrawElementSkeleton = {
-        type: "rectangle",
-        x: vertex.x,
-        y: vertex.y,
-        width: vertex.width,
-        height: vertex.height,
-        label: {
-          text: vertex.text,
-          fontSize,
-          verticalAlign: "middle",
-        },
-      };
-      elements.push(container);
+      node.forEach((element) => {
+        let excalidrawElement: ExcalidrawElementSkeleton;
+
+        switch (element.type) {
+          case "line":
+            excalidrawElement = createLine(element);
+            break;
+
+          case "rectangle":
+          case "ellipse":
+            excalidrawElement = createContainer(element, options);
+            break;
+
+          case "text":
+            excalidrawElement = createText(element);
+            break;
+          default:
+            throw `unknown type ${element.type}`;
+            break;
+        }
+        elements.push(excalidrawElement);
+      });
     });
 
     Object.values(chart.lines).forEach((line) => {
       if (!line) {
         return;
       }
-      const lineElement: ExcalidrawElementSkeleton = {
-        type: "line",
-        x: line.startX,
-        y: line.startY,
-        points: [
-          [0, 0],
-          [line.endX - line.startX, line.endY - line.startY],
-        ],
-        width: line.endX - line.startX,
-        height: line.endY - line.startY,
-      };
-      elements.push(lineElement);
+      elements.push(createLine(line));
     });
 
     Object.values(chart.arrows).forEach((arrow) => {
       if (!arrow) {
         return;
       }
-      const strokeStyle = EXCALIDRAW_STROKE_STYLE_FOR_ARROW[arrow.strokeStyle];
-      console.log(arrow.strokeStyle, "HEYYYY");
-      const arrowElement: ExcalidrawElementSkeleton = {
-        type: "arrow",
-        x: arrow.startX,
-        y: arrow.startY,
-        points: [
-          [0, 0],
-          [arrow.endX - arrow.startX, arrow.endY - arrow.startY],
-        ],
-        width: arrow.endX - arrow.startX,
-        height: arrow.endY - arrow.startY,
-        strokeStyle,
-        endArrowhead:
-          arrow.strokeStyle === "SOLID_OPEN" ||
-          arrow.strokeStyle === "DOTTED_OPEN"
-            ? null
-            : "arrow",
-        label: {
-          text: arrow.text || "",
-        },
-      };
-      elements.push(arrowElement);
+
+      elements.push(createArrow(arrow));
     });
+    console.log(elements, "ELEMNETS");
     return { elements };
   },
 });

--- a/src/converter/types/sequence.ts
+++ b/src/converter/types/sequence.ts
@@ -215,10 +215,18 @@ export const SequenceToExcalidrawSkeletonConvertor = new GraphConverter({
           }
         });
         actors.forEach((actor) => {
-          minX = Math.min(minX, actor.x!);
-          minY = Math.min(minY, actor.y!);
-          maxX = Math.max(maxX, actor.x! + actor.width!);
-          maxY = Math.max(maxY, actor.y! + actor.height!);
+          if (
+            actor.x === undefined ||
+            actor.y === undefined ||
+            actor.width === undefined ||
+            actor.height === undefined
+          ) {
+            throw new Error(`Actor attributes missing ${actor}`);
+          }
+          minX = Math.min(minX, actor.x);
+          minY = Math.min(minY, actor.y);
+          maxX = Math.max(maxX, actor.x + actor.width);
+          maxY = Math.max(maxY, actor.y + actor.height);
         });
         // Draw the outer rectangle enclosing the group elements
         const PADDING = 10;
@@ -226,7 +234,7 @@ export const SequenceToExcalidrawSkeletonConvertor = new GraphConverter({
         const groupRectY = minY - PADDING;
         const groupRectWidth = maxX - minX + PADDING * 2;
         const groupRectHeight = maxY - minY + PADDING * 2;
-
+        const groupRectId = nanoid();
         const groupRect = createContainer({
           type: "rectangle",
           x: groupRectX,
@@ -234,24 +242,36 @@ export const SequenceToExcalidrawSkeletonConvertor = new GraphConverter({
           width: groupRectWidth,
           height: groupRectHeight,
           bgColor: group.fill,
-          id: nanoid(),
+          id: groupRectId,
         });
         elements.unshift(groupRect);
         const frameId = nanoid();
 
-        const frameChildren: ExcalidrawElement["id"][] = [groupRect.id!];
+        const frameChildren: ExcalidrawElement["id"][] = [groupRectId];
 
         elements.forEach((ele) => {
+          if (ele.type === "frame") {
+            return;
+          }
           if (
-            ele.x! >= minX &&
-            ele.x! + ele.width! <= maxX &&
-            ele.y! >= minY &&
-            ele.y! + ele.height! <= maxY
+            ele.x === undefined ||
+            ele.y === undefined ||
+            ele.width === undefined ||
+            ele.height === undefined
           ) {
+            throw new Error(`Element attributes missing ${ele}`);
+          }
+          if (
+            ele.x >= minX &&
+            ele.x + ele.width <= maxX &&
+            ele.y >= minY &&
+            ele.y + ele.height <= maxY
+          ) {
+            const elementId = ele.id || nanoid();
             if (!ele.id) {
-              Object.assign(ele, { id: nanoid() });
+              Object.assign(ele, { id: elementId });
             }
-            frameChildren.push(ele.id!);
+            frameChildren.push(elementId);
           }
         });
 

--- a/src/converter/types/sequence.ts
+++ b/src/converter/types/sequence.ts
@@ -59,6 +59,7 @@ export const SequenceToExcalidrawSkeletonConvertor = new GraphConverter({
       if (!arrow) {
         return;
       }
+      const strokeStyle = EXCALIDRAW_STROKE_STYLE_FOR_ARROW[arrow.strokeStyle];
       const arrowElement: ExcalidrawElementSkeleton = {
         type: "arrow",
         x: arrow.startX,
@@ -69,15 +70,18 @@ export const SequenceToExcalidrawSkeletonConvertor = new GraphConverter({
         ],
         width: arrow.endX - arrow.startX,
         height: arrow.endY - arrow.startY,
-        strokeStyle: EXCALIDRAW_STROKE_STYLE_FOR_ARROW[arrow.arrowType],
-
+        strokeStyle,
+        endArrowhead:
+          strokeStyle === EXCALIDRAW_STROKE_STYLE_FOR_ARROW.SOLID ||
+          strokeStyle === EXCALIDRAW_STROKE_STYLE_FOR_ARROW.DOTTED
+            ? null
+            : "arrow",
         label: {
           text: arrow.text || "",
         },
       };
       elements.push(arrowElement);
     });
-    console.log(elements, "ELEMENTS");
     return { elements };
   },
 });

--- a/src/converter/types/sequence.ts
+++ b/src/converter/types/sequence.ts
@@ -2,7 +2,11 @@ import { ExcalidrawElementSkeleton } from "@excalidraw/excalidraw/types/data/tra
 import { GraphConverter } from "../GraphConverter.js";
 
 import { Arrow, Line, Node, Sequence, Text } from "../../parser/sequence.js";
-import { StrokeStyle } from "@excalidraw/excalidraw/types/element/types.js";
+import {
+  ExcalidrawFrameElement,
+  StrokeStyle,
+} from "@excalidraw/excalidraw/types/element/types.js";
+import { nanoid } from "nanoid";
 
 // Arrow mapper for the supported sequence arrow types
 const EXCALIDRAW_STROKE_STYLE_FOR_ARROW: { [key: string]: StrokeStyle } = {
@@ -57,6 +61,7 @@ const createContainer = (element: Exclude<Node, Line | Arrow | Text>) => {
     };
   }
   const container: ExcalidrawElementSkeleton = {
+    id: element.id,
     type: element.type,
     x: element.x,
     y: element.y,
@@ -173,6 +178,83 @@ export const SequenceToExcalidrawSkeletonConvertor = new GraphConverter({
       });
     }
 
+    if (chart.groups) {
+      chart.groups.forEach((group) => {
+        const { actorKeys, name } = group;
+        let minX = Infinity;
+        let minY = Infinity;
+        let maxX = 0;
+        let maxY = 0;
+        if (!actorKeys.length) {
+          return;
+        }
+        const actors = elements.filter((ele) => {
+          if (ele.id) {
+            const hyphenIndex = ele.id.indexOf("-");
+            const id = ele.id.substring(0, hyphenIndex);
+            return actorKeys.includes(id);
+          }
+        });
+        actors.forEach((actor) => {
+          minX = Math.min(minX, actor.x);
+          minY = Math.min(minY, actor.y);
+          maxX = Math.max(maxX, actor.x + actor.width!);
+          maxY = Math.max(maxY, actor.y + actor.height!);
+        });
+
+        const frameId = nanoid();
+        // There is a outer rectangle drawn to enclose the group/box in mermaid, these calculations are so we can include that rectangle inside the frame as well.
+        // Later we will remove this and draw our own rectangle instead to simplify. Currently that isn't possible as we want to support background highlight as well and there is no clear distinction between group and highlight on DOM.
+        const padding = 20;
+        const yOffset = 25;
+        minX -= padding;
+        minY -= yOffset + padding;
+        maxX += padding;
+        maxY += yOffset;
+        const width = maxX - minX;
+        const height = maxY - minY;
+        elements.forEach((ele) => {
+          if (
+            ele.x >= minX &&
+            ele.x + ele.width! <= maxX &&
+            ele.y >= minY &&
+            ele.y + ele.height! <= maxY
+          ) {
+            Object.assign(ele, { frameId });
+          }
+        });
+        // TODO remove extra attributes once we support frames in programmatic API
+        const frame: ExcalidrawFrameElement = {
+          type: "frame",
+          version: 262,
+          versionNonce: 1383486180,
+          isDeleted: false,
+          id: frameId,
+          fillStyle: "solid",
+          strokeWidth: 1,
+          strokeStyle: "solid",
+          roughness: 0,
+          opacity: 100,
+          angle: 0,
+          x: minX,
+          y: minY,
+          strokeColor: "#bbb",
+          backgroundColor: "transparent",
+          width,
+          height,
+          seed: 1792453604,
+          groupIds: [],
+          frameId: null,
+          roundness: null,
+          boundElements: [],
+          updated: 1697731885168,
+          link: null,
+          locked: false,
+          name,
+        };
+        elements.push(frame);
+      });
+    }
     return { elements };
   },
 });

--- a/src/converter/types/sequence.ts
+++ b/src/converter/types/sequence.ts
@@ -85,7 +85,7 @@ const createArrow = (arrow: Arrow) => {
     type: "arrow",
     x: arrow.startX,
     y: arrow.startY,
-    points: [
+    points: arrow.points || [
       [0, 0],
       [arrow.endX - arrow.startX, arrow.endY - arrow.startY],
     ],
@@ -99,6 +99,9 @@ const createArrow = (arrow: Arrow) => {
     label: {
       text: arrow?.label?.text || "",
       fontSize: 16,
+    },
+    roundness: {
+      type: 2,
     },
   };
   return arrowElement;

--- a/src/converter/types/sequence.ts
+++ b/src/converter/types/sequence.ts
@@ -66,10 +66,13 @@ const createContainer = (element: Exclude<Node, Line | Arrow | Text>) => {
       text: element?.label?.text || "",
       fontSize: element?.label?.fontSize,
       verticalAlign: "middle",
+      strokeColor: "#000",
     },
     strokeStyle: element?.strokeStyle,
     strokeWidth: element?.strokeWidth,
+    strokeColor: element?.strokeColor,
     backgroundColor: element?.bgColor,
+    fillStyle: "solid",
     ...extraProps,
   };
 
@@ -154,12 +157,15 @@ export const SequenceToExcalidrawSkeletonConvertor = new GraphConverter({
     elements.push(...activations);
 
     // loops
-    const { lines, texts } = chart.loops;
+    const { lines, texts, nodes } = chart.loops;
     lines.forEach((line) => {
       elements.push(createLine(line));
     });
     texts.forEach((text) => {
       elements.push(createText(text));
+    });
+    nodes.forEach((node) => {
+      elements.push(createContainer(node));
     });
 
     return { elements };

--- a/src/converter/types/sequence.ts
+++ b/src/converter/types/sequence.ts
@@ -9,6 +9,7 @@ const EXCALIDRAW_STROKE_STYLE_FOR_ARROW: { [key: string]: StrokeStyle } = {
   DOTTED: "dotted",
   SOLID_CROSS: "solid",
   DOTTED_CROSS: "dotted",
+  SOLID_OPEN: "solid",
   DOTTED_OPEN: "dotted",
   SOLID_POINT: "solid",
   DOTTED_POINT: "dotted",
@@ -17,7 +18,6 @@ export const SequenceToExcalidrawSkeletonConvertor = new GraphConverter({
   converter: (chart: Sequence, options: any) => {
     const elements: ExcalidrawElementSkeleton[] = [];
     const fontSize = options.fontSize;
-    console.log(chart, "CHART");
     Object.values(chart.nodes).forEach((vertex) => {
       if (!vertex) {
         return;
@@ -60,6 +60,7 @@ export const SequenceToExcalidrawSkeletonConvertor = new GraphConverter({
         return;
       }
       const strokeStyle = EXCALIDRAW_STROKE_STYLE_FOR_ARROW[arrow.strokeStyle];
+      console.log(arrow.strokeStyle, "HEYYYY");
       const arrowElement: ExcalidrawElementSkeleton = {
         type: "arrow",
         x: arrow.startX,
@@ -72,8 +73,8 @@ export const SequenceToExcalidrawSkeletonConvertor = new GraphConverter({
         height: arrow.endY - arrow.startY,
         strokeStyle,
         endArrowhead:
-          strokeStyle === EXCALIDRAW_STROKE_STYLE_FOR_ARROW.SOLID ||
-          strokeStyle === EXCALIDRAW_STROKE_STYLE_FOR_ARROW.DOTTED
+          arrow.strokeStyle === "SOLID_OPEN" ||
+          arrow.strokeStyle === "DOTTED_OPEN"
             ? null
             : "arrow",
         label: {

--- a/src/converter/types/sequence.ts
+++ b/src/converter/types/sequence.ts
@@ -298,7 +298,6 @@ export const SequenceToExcalidrawSkeletonConvertor = new GraphConverter({
         elements.push(frame);
       });
     }
-    console.log(elements, "excalidraw elements");
     return { elements };
   },
 });

--- a/src/converter/types/sequence.ts
+++ b/src/converter/types/sequence.ts
@@ -157,16 +157,18 @@ export const SequenceToExcalidrawSkeletonConvertor = new GraphConverter({
     elements.push(...activations);
 
     // loops
-    const { lines, texts, nodes } = chart.loops;
-    lines.forEach((line) => {
-      elements.push(createLine(line));
-    });
-    texts.forEach((text) => {
-      elements.push(createText(text));
-    });
-    nodes.forEach((node) => {
-      elements.push(createContainer(node));
-    });
+    if (chart.loops) {
+      const { lines, texts, nodes } = chart.loops;
+      lines.forEach((line) => {
+        elements.push(createLine(line));
+      });
+      texts.forEach((text) => {
+        elements.push(createText(text));
+      });
+      nodes.forEach((node) => {
+        elements.push(createContainer(node));
+      });
+    }
 
     return { elements };
   },

--- a/src/converter/types/sequence.ts
+++ b/src/converter/types/sequence.ts
@@ -77,7 +77,7 @@ const createContainer = (element: Exclude<Node, Line | Arrow | Text>) => {
       text: element?.label?.text || "",
       fontSize: element?.label?.fontSize,
       verticalAlign: "middle",
-      strokeColor: "#000",
+      strokeColor: element.label?.color || "#000",
     },
     strokeStyle: element?.strokeStyle,
     strokeWidth: element?.strokeWidth,
@@ -173,6 +173,9 @@ export const SequenceToExcalidrawSkeletonConvertor = new GraphConverter({
       }
 
       elements.push(createArrow(arrow));
+      if (arrow.sequenceNumber) {
+        elements.push(createContainer(arrow.sequenceNumber));
+      }
     });
     elements.push(...activations);
 

--- a/src/converter/types/sequence.ts
+++ b/src/converter/types/sequence.ts
@@ -35,6 +35,9 @@ const createLine = (line: Line) => {
     strokeColor: line.strokeColor || "#000",
     strokeWidth: line.strokeWidth || 1,
   };
+  if (line.groupId) {
+    Object.assign(lineElement, { groupIds: [line.groupId] });
+  }
   return lineElement;
 };
 
@@ -49,6 +52,9 @@ const createText = (element: Text) => {
     fontSize: element.fontSize,
     verticalAlign: "middle",
   };
+  if (element.groupId) {
+    Object.assign(textElement, { groupIds: [element.groupId] });
+  }
   return textElement;
 };
 
@@ -80,6 +86,9 @@ const createContainer = (element: Exclude<Node, Line | Arrow | Text>) => {
     fillStyle: "solid",
     ...extraProps,
   };
+  if (element.groupId) {
+    Object.assign(container, { groupIds: [element.groupId] });
+  }
 
   return container;
 };
@@ -109,6 +118,9 @@ const createArrow = (arrow: Arrow) => {
       type: 2,
     },
   };
+  if (arrow.groupId) {
+    Object.assign(arrowElement, { groupIds: [arrow.groupId] });
+  }
   return arrowElement;
 };
 

--- a/src/converter/types/sequence.ts
+++ b/src/converter/types/sequence.ts
@@ -1,4 +1,7 @@
-import { ExcalidrawElementSkeleton } from "@excalidraw/excalidraw/types/data/transform.js";
+import {
+  ExcalidrawElementSkeleton,
+  ValidContainer,
+} from "@excalidraw/excalidraw/types/data/transform.js";
 import { GraphConverter } from "../GraphConverter.js";
 
 import { Arrow, Line, Node, Sequence, Text } from "../../parser/sequence.js";
@@ -256,6 +259,11 @@ export const SequenceToExcalidrawSkeletonConvertor = new GraphConverter({
             ele.y + ele.height! <= frameY2
           ) {
             Object.assign(ele, { frameId });
+            if ((ele as ValidContainer)?.label?.text) {
+              Object.assign(ele, {
+                label: { ...(ele as ValidContainer).label, frameId },
+              });
+            }
           }
         });
         // TODO remove extra attributes once we support frames in programmatic API
@@ -290,6 +298,7 @@ export const SequenceToExcalidrawSkeletonConvertor = new GraphConverter({
         elements.push(frame);
       });
     }
+    console.log(elements, "excalidraw elements");
     return { elements };
   },
 });

--- a/src/converter/types/sequence.ts
+++ b/src/converter/types/sequence.ts
@@ -1,13 +1,8 @@
 import { ExcalidrawElementSkeleton } from "@excalidraw/excalidraw/types/data/transform.js";
 import { GraphConverter } from "../GraphConverter.js";
-import {
-  ExcalidrawRectangleElement,
-  ExcalidrawTextElement,
-  StrokeStyle,
-} from "@excalidraw/excalidraw/types/element/types.js";
-import { Arrow, Line, Node, Sequence } from "../../parser/sequence.js";
-import { ExcalidrawElement } from "../../types.js";
-import { MermaidOptions } from "../../index.js";
+
+import { Arrow, Line, Node, Sequence, Text } from "../../parser/sequence.js";
+import { StrokeStyle } from "@excalidraw/excalidraw/types/element/types.js";
 
 // Arrow mapper for the supported sequence arrow types
 const EXCALIDRAW_STROKE_STYLE_FOR_ARROW: { [key: string]: StrokeStyle } = {
@@ -22,7 +17,6 @@ const EXCALIDRAW_STROKE_STYLE_FOR_ARROW: { [key: string]: StrokeStyle } = {
 };
 
 const createLine = (line: Line) => {
-  console.log(line, "LINE");
   const lineElement: ExcalidrawElementSkeleton = {
     type: "line",
     x: line.startX,
@@ -34,11 +28,10 @@ const createLine = (line: Line) => {
     width: line.endX - line.startX,
     height: line.endY - line.startY,
   };
-  console.log(lineElement);
   return lineElement;
 };
 
-const createText = (element: Node) => {
+const createText = (element: Text) => {
   const textElement: ExcalidrawElementSkeleton = {
     type: "text",
     x: element.x,
@@ -52,7 +45,7 @@ const createText = (element: Node) => {
   return textElement;
 };
 
-const createContainer = (element: Node, options: MermaidOptions) => {
+const createContainer = (element: Exclude<Node, Line | Arrow | Text>) => {
   const container: ExcalidrawElementSkeleton = {
     type: element.type,
     x: element.x,
@@ -60,8 +53,8 @@ const createContainer = (element: Node, options: MermaidOptions) => {
     width: element.width,
     height: element.height,
     label: {
-      text: element.text || "",
-      fontSize: options.fontSize,
+      text: element?.label?.text || "",
+      fontSize: element?.label?.fontSize,
       verticalAlign: "middle",
     },
   };
@@ -86,13 +79,15 @@ const createArrow = (arrow: Arrow) => {
         ? null
         : "arrow",
     label: {
-      text: arrow.text || "",
+      text: arrow?.label?.text || "",
+      fontSize: 16,
     },
   };
   return arrowElement;
 };
+
 export const SequenceToExcalidrawSkeletonConvertor = new GraphConverter({
-  converter: (chart: Sequence, options: any) => {
+  converter: (chart: Sequence) => {
     const elements: ExcalidrawElementSkeleton[] = [];
     Object.values(chart.nodes).forEach((node) => {
       if (!node || !node.length) {
@@ -108,7 +103,7 @@ export const SequenceToExcalidrawSkeletonConvertor = new GraphConverter({
 
           case "rectangle":
           case "ellipse":
-            excalidrawElement = createContainer(element, options);
+            excalidrawElement = createContainer(element);
             break;
 
           case "text":
@@ -136,7 +131,6 @@ export const SequenceToExcalidrawSkeletonConvertor = new GraphConverter({
 
       elements.push(createArrow(arrow));
     });
-    console.log(elements, "ELEMNETS");
     return { elements };
   },
 });

--- a/src/converter/types/sequence.ts
+++ b/src/converter/types/sequence.ts
@@ -46,6 +46,13 @@ const createText = (element: Text) => {
 };
 
 const createContainer = (element: Exclude<Node, Line | Arrow | Text>) => {
+  let extraProps = {};
+  if (element.type === "rectangle" && element.subtype === "activation") {
+    extraProps = {
+      backgroundColor: "#e9ecef",
+      fillStyle: "solid",
+    };
+  }
   const container: ExcalidrawElementSkeleton = {
     type: element.type,
     x: element.x,
@@ -59,7 +66,10 @@ const createContainer = (element: Exclude<Node, Line | Arrow | Text>) => {
     },
     strokeStyle: element?.strokeStyle,
     strokeWidth: element?.strokeWidth,
+    backgroundColor: element?.bgColor,
+    ...extraProps,
   };
+
   return container;
 };
 
@@ -91,6 +101,7 @@ const createArrow = (arrow: Arrow) => {
 export const SequenceToExcalidrawSkeletonConvertor = new GraphConverter({
   converter: (chart: Sequence) => {
     const elements: ExcalidrawElementSkeleton[] = [];
+    const activations: ExcalidrawElementSkeleton[] = [];
     Object.values(chart.nodes).forEach((node) => {
       if (!node || !node.length) {
         return;
@@ -115,7 +126,11 @@ export const SequenceToExcalidrawSkeletonConvertor = new GraphConverter({
             throw `unknown type ${element.type}`;
             break;
         }
-        elements.push(excalidrawElement);
+        if (element.type === "rectangle" && element?.subtype === "activation") {
+          activations.push(excalidrawElement);
+        } else {
+          elements.push(excalidrawElement);
+        }
       });
     });
 
@@ -133,6 +148,7 @@ export const SequenceToExcalidrawSkeletonConvertor = new GraphConverter({
 
       elements.push(createArrow(arrow));
     });
+    elements.push(...activations);
     return { elements };
   },
 });

--- a/src/graphToExcalidraw.ts
+++ b/src/graphToExcalidraw.ts
@@ -1,10 +1,13 @@
 import { MermaidOptions } from "./index.js";
 import { FlowchartToExcalidrawSkeletonConverter } from "./converter/types/flowchart.js";
 import { GraphImageConverter } from "./converter/types/graphImage.js";
-import { Graph, GraphImage, MermaidToExcalidrawResult } from "./interfaces.js";
+import { GraphImage, MermaidToExcalidrawResult } from "./interfaces.js";
+import { SequenceToExcalidrawSkeletonConvertor } from "./converter/types/sequence.js";
+import { Sequence } from "./parser/sequence.js";
+import { Flowchart } from "./parser/flowchart.js";
 
 export const graphToExcalidraw = (
-  graph: Graph | GraphImage,
+  graph: Flowchart | GraphImage | Sequence,
   options: MermaidOptions = {}
 ): MermaidToExcalidrawResult => {
   switch (graph.type) {
@@ -13,6 +16,9 @@ export const graphToExcalidraw = (
     }
     case "flowchart": {
       return FlowchartToExcalidrawSkeletonConverter.convert(graph, options);
+    }
+    case "sequence": {
+      return SequenceToExcalidrawSkeletonConvertor.convert(graph, options);
     }
     default: {
       throw new Error(

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,7 @@ const parseMermaidToExcalidraw = async (
   definition: string,
   options: MermaidOptions = {}
 ) => {
-  const parsedMermaidData = await parseMermaid(definition, options);
+  const parsedMermaidData = await parseMermaid(definition);
   const excalidrawElements = graphToExcalidraw(parsedMermaidData, options);
   return excalidrawElements;
 };

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -47,35 +47,12 @@ export interface Position {
   y: number;
 }
 
-export interface Edge {
-  start: string;
-  end: string;
-  type: string;
-  text: string;
-  labelType: string;
-  stroke: string;
-  startX: number;
-  startY: number;
-  endX: number;
-  endY: number;
-  reflectionPoints: Position[];
-}
-
 export interface GraphImage {
   type: "graphImage";
   mimeType: string;
   dataURL: string;
   width: number;
   height: number;
-}
-
-type ImplementedGraphTypes = "flowchart";
-
-export interface Graph {
-  type: ImplementedGraphTypes;
-  subGraphs: SubGraph[];
-  vertices: { [key: string]: Vertex | undefined };
-  edges: Edge[];
 }
 
 export interface MermaidToExcalidrawResult {

--- a/src/parseMermaid.ts
+++ b/src/parseMermaid.ts
@@ -1,34 +1,9 @@
 import mermaid from "mermaid";
 import { GraphImage } from "./interfaces.js";
 import { DEFAULT_FONT_SIZE } from "./constants.js";
-import { encodeEntities, isSupportedDiagram } from "./utils.js";
+import { encodeEntities } from "./utils.js";
 import { Flowchart, parseMermaidFlowChartDiagram } from "./parser/flowchart.js";
 import { Sequence, parseMermaidSequenceDiagram } from "./parser/sequence.js";
-
-interface MermaidDefinitionOptions {
-  curve?: "linear" | "basis";
-}
-
-const processMermaidTextWithOptions = (
-  definition: string,
-  options?: MermaidDefinitionOptions
-) => {
-  const diagramInitOptions = {
-    // Add options for rendering flowchart in linear curves (for better extracting arrow path points) and custom font size
-    flowchart: {
-      curve: options?.curve || "basis",
-    },
-    // Increase the Mermaid's font size by multiplying with 1.25 to match the Excalidraw Virgil font
-    themeVariables: {
-      fontSize: `${DEFAULT_FONT_SIZE * 1.25}px`,
-    },
-  };
-  const fullDefinition = `%%{init: ${JSON.stringify(
-    diagramInitOptions
-  )}}%%\n${definition}`;
-
-  return fullDefinition;
-};
 
 // Fallback to Svg
 const convertSvgToGraphImage = (svgContainer: HTMLDivElement) => {
@@ -69,18 +44,21 @@ const convertSvgToGraphImage = (svgContainer: HTMLDivElement) => {
 export const parseMermaid = async (
   definition: string
 ): Promise<Flowchart | GraphImage | Sequence> => {
-  mermaid.initialize({ startOnLoad: false });
-
-  const fullDefinition = processMermaidTextWithOptions(definition, {
-    curve: isSupportedDiagram(definition) ? "linear" : "basis",
+  mermaid.initialize({
+    startOnLoad: false,
+    flowchart: { curve: "linear" },
+    themeVariables: {
+      fontSize: `${DEFAULT_FONT_SIZE * 1.25}px`,
+    },
   });
+
   // Parse the diagram
   const diagram = await mermaid.mermaidAPI.getDiagramFromText(
-    encodeEntities(fullDefinition)
+    encodeEntities(definition)
   );
 
   // Render the SVG diagram
-  const { svg } = await mermaid.render("mermaid-to-excalidraw", fullDefinition);
+  const { svg } = await mermaid.render("mermaid-to-excalidraw", definition);
 
   // Append Svg to DOM
   const svgContainer = document.createElement("div");

--- a/src/parseMermaid.ts
+++ b/src/parseMermaid.ts
@@ -8,7 +8,6 @@ import { Sequence, parseMermaidSequenceDiagram } from "./parser/sequence.js";
 
 interface MermaidDefinitionOptions {
   curve?: "linear" | "basis";
-  fontSize?: number;
 }
 
 const processMermaidTextWithOptions = (
@@ -22,7 +21,7 @@ const processMermaidTextWithOptions = (
     },
     // Increase the Mermaid's font size by multiplying with 1.25 to match the Excalidraw Virgil font
     themeVariables: {
-      fontSize: `${(options?.fontSize || DEFAULT_FONT_SIZE) * 1.25}px`,
+      fontSize: `${DEFAULT_FONT_SIZE * 1.25}px`,
     },
   };
   const fullDefinition = `%%{init: ${JSON.stringify(

--- a/src/parseMermaid.ts
+++ b/src/parseMermaid.ts
@@ -1,7 +1,6 @@
 import mermaid from "mermaid";
 import { GraphImage } from "./interfaces.js";
 import { DEFAULT_FONT_SIZE } from "./constants.js";
-import { MermaidOptions } from "./index.js";
 import { isSupportedDiagram } from "./utils.js";
 import { Flowchart, parseMermaidFlowChartDiagram } from "./parser/flowchart.js";
 import { Sequence, parseMermaidSequenceDiagram } from "./parser/sequence.js";

--- a/src/parseMermaid.ts
+++ b/src/parseMermaid.ts
@@ -68,14 +68,12 @@ const convertSvgToGraphImage = (svgContainer: HTMLDivElement) => {
 };
 
 export const parseMermaid = async (
-  definition: string,
-  options: MermaidOptions = {}
+  definition: string
 ): Promise<Flowchart | GraphImage | Sequence> => {
   mermaid.initialize({ startOnLoad: false });
 
   const fullDefinition = processMermaidTextWithOptions(definition, {
     curve: isSupportedDiagram(definition) ? "linear" : "basis",
-    fontSize: options.fontSize,
   });
   // Parse the diagram
   const diagram = await mermaid.mermaidAPI.getDiagramFromText(fullDefinition);

--- a/src/parseMermaid.ts
+++ b/src/parseMermaid.ts
@@ -1,7 +1,7 @@
 import mermaid from "mermaid";
 import { GraphImage } from "./interfaces.js";
 import { DEFAULT_FONT_SIZE } from "./constants.js";
-import { isSupportedDiagram } from "./utils.js";
+import { encodeEntities, isSupportedDiagram } from "./utils.js";
 import { Flowchart, parseMermaidFlowChartDiagram } from "./parser/flowchart.js";
 import { Sequence, parseMermaidSequenceDiagram } from "./parser/sequence.js";
 
@@ -75,7 +75,9 @@ export const parseMermaid = async (
     curve: isSupportedDiagram(definition) ? "linear" : "basis",
   });
   // Parse the diagram
-  const diagram = await mermaid.mermaidAPI.getDiagramFromText(fullDefinition);
+  const diagram = await mermaid.mermaidAPI.getDiagramFromText(
+    encodeEntities(fullDefinition)
+  );
 
   // Render the SVG diagram
   const { svg } = await mermaid.render("mermaid-to-excalidraw", fullDefinition);

--- a/src/parseMermaid.ts
+++ b/src/parseMermaid.ts
@@ -1,9 +1,10 @@
 import mermaid from "mermaid";
-import { Graph, GraphImage } from "./interfaces.js";
+import { GraphImage } from "./interfaces.js";
 import { DEFAULT_FONT_SIZE } from "./constants.js";
 import { MermaidOptions } from "./index.js";
 import { isSupportedDiagram } from "./utils.js";
-import { parseMermaidFlowChartDiagram } from "./parser/flowchart.js";
+import { Flowchart, parseMermaidFlowChartDiagram } from "./parser/flowchart.js";
+import { Sequence, parseMermaidSequenceDiagram } from "./parser/sequence.js";
 
 interface MermaidDefinitionOptions {
   curve?: "linear" | "basis";
@@ -70,7 +71,7 @@ const convertSvgToGraphImage = (svgContainer: HTMLDivElement) => {
 export const parseMermaid = async (
   definition: string,
   options: MermaidOptions = {}
-): Promise<Graph | GraphImage> => {
+): Promise<Flowchart | GraphImage | Sequence> => {
   mermaid.initialize({ startOnLoad: false });
 
   const fullDefinition = processMermaidTextWithOptions(definition, {
@@ -97,6 +98,12 @@ export const parseMermaid = async (
   switch (diagram.type) {
     case "flowchart-v2": {
       data = parseMermaidFlowChartDiagram(diagram, svgContainer);
+      break;
+    }
+
+    case "sequence": {
+      data = parseMermaidSequenceDiagram(diagram, svgContainer);
+
       break;
     }
     // fallback to image if diagram type not-supported

--- a/src/parser/flowchart.ts
+++ b/src/parser/flowchart.ts
@@ -1,8 +1,6 @@
 import { entityCodesToText, getTransformAttr } from "../utils.js";
 import {
   CONTAINER_STYLE_PROPERTY,
-  Edge,
-  Graph,
   LABEL_STYLE_PROPERTY,
   Position,
   SubGraph,
@@ -10,6 +8,28 @@ import {
 } from "../interfaces.js";
 
 import { Diagram } from "mermaid/dist/Diagram.js";
+
+export interface Flowchart {
+  type: "flowchart";
+  subGraphs: SubGraph[];
+  vertices: { [key: string]: Vertex | undefined };
+  edges: Edge[];
+}
+
+export interface Edge {
+  id?: string;
+  start: string;
+  end: string;
+  type: string;
+  text: string;
+  labelType: string;
+  stroke: string;
+  startX: number;
+  startY: number;
+  endX: number;
+  endY: number;
+  reflectionPoints: Position[];
+}
 
 const parseSubGraph = (data: any, containerEl: Element): SubGraph => {
   // Extract only node id for better reference
@@ -256,7 +276,7 @@ const computeEdgePositions = (
 export const parseMermaidFlowChartDiagram = (
   diagram: Diagram,
   containerEl: Element
-): Graph => {
+): Flowchart => {
   // This does some cleanup and initialization making sure
   // diagram is parsed correctly. Useful when multiple diagrams are
   // parsed together one after another, eg in playground

--- a/src/parser/sequence.ts
+++ b/src/parser/sequence.ts
@@ -48,6 +48,7 @@ export type Container = {
   height: number;
   strokeStyle?: "dashed" | "solid";
   strokeWidth?: number;
+  strokeColor?: string;
   bgColor?: string;
   subtype?: "activation";
 };
@@ -56,6 +57,7 @@ export type Node = Container | Line | Arrow | Text;
 type Loop = {
   lines: Line[];
   texts: Text[];
+  nodes: Container[];
 };
 export interface Sequence {
   type: "sequence";
@@ -344,6 +346,7 @@ const parseLoops = (containerEl: Element) => {
   ) as SVGLineElement[];
   const lines: Line[] = [];
   const texts: Text[] = [];
+  const nodes: Container[] = [];
   lineNodes.forEach((node) => {
     const startX = Number(node.getAttribute("x1"));
     const startY = Number(node.getAttribute("y1"));
@@ -359,15 +362,24 @@ const parseLoops = (containerEl: Element) => {
   const loopText = Array.from(
     containerEl.querySelectorAll(".loopText")
   ) as SVGTextElement[];
+
   loopText.forEach((node) => {
     const text = node.textContent || "";
     const textElement = createTextElement(node, text);
-    texts.push(textElement);
 
-    const label = node.previousElementSibling as SVGTextElement;
-    texts.push(createTextElement(label, label.textContent || ""));
+    texts.push(textElement);
+    const parentElement = node.parentElement;
+    const labelBox = parentElement?.querySelector(
+      ".labelBox"
+    )! as SVGSVGElement;
+    const labelText =
+      parentElement?.querySelector(".labelText")?.textContent || "";
+    const container = createContainerElement(labelBox, "rectangle", labelText);
+    container.strokeColor = "#adb5bd";
+    container.bgColor = "#e9ecef";
+    nodes.push(container);
   });
-  return { lines, texts };
+  return { lines, texts, nodes };
 };
 
 export const parseMermaidSequenceDiagram = (

--- a/src/parser/sequence.ts
+++ b/src/parser/sequence.ts
@@ -454,11 +454,13 @@ const parseActor = (actors: { [key: string]: Actor }, containerEl: Element) => {
       const endX = Number(lineNode.getAttribute("x2"));
       // Make sure lines don't overlap with the nodes, in mermaid it overlaps but isn't visible as its pushed back and containers are non transparent
       const bottomEllipseNode = bottomNodeElement.find(
-        (node) => node.type === "ellipse"
-      ) as Container;
-      const endY = bottomEllipseNode.y;
-      const line = createLineElement(lineNode, startX, startY, endX, endY);
-      lines.push(line);
+        (node): node is Container => node.type === "ellipse"
+      );
+      if (bottomEllipseNode) {
+        const endY = bottomEllipseNode.y;
+        const line = createLineElement(lineNode, startX, startY, endX, endY);
+        lines.push(line);
+      }
     }
   });
 
@@ -468,9 +470,9 @@ const parseActor = (actors: { [key: string]: Actor }, containerEl: Element) => {
 const computeArrows = (messages: Message[], containerEl: Element) => {
   const arrows: Arrow[] = [];
 
-  const arrowNodes = Array.from(
+  const arrowNodes = Array.from<SVGLineElement>(
     containerEl.querySelectorAll('[class*="messageLine"]')
-  ) as SVGLineElement[];
+  );
   const supportedMessageTypes = Object.keys(SEQUENCE_ARROW_TYPES);
   const arrowMessages = messages.filter((message) =>
     supportedMessageTypes.includes(message.type.toString())

--- a/src/parser/sequence.ts
+++ b/src/parser/sequence.ts
@@ -230,21 +230,18 @@ const parseMessages = (messages: Message[], containerEl: Element) => {
   ) as SVGLineElement[];
 
   arrowNodes.forEach((arrowNode, index) => {
-    const textNode = arrowNode.nextElementSibling as SVGTextElement | null;
     const message = messages[index];
     const arrow = {} as Arrow;
-    if (textNode) {
-      arrow.text = textNode.textContent;
-      arrow.startX = Number(arrowNode.getAttribute("x1"));
-      arrow.startY = Number(arrowNode.getAttribute("y1"));
-      arrow.endX = Number(arrowNode.getAttribute("x2"));
-      arrow.endY = Number(arrowNode.getAttribute("y2"));
-      arrow.strokeColor = arrowNode.getAttribute("stroke");
-      arrow.strokeWidth = arrowNode.getAttribute("stroke-width");
-      arrow.type = "arrow";
-      arrow.strokeStyle = SUPPORTED_SEQUENCE_ARROW_TYPES[message.type];
-      arrows.push(arrow);
-    }
+    arrow.text = message.message;
+    arrow.startX = Number(arrowNode.getAttribute("x1"));
+    arrow.startY = Number(arrowNode.getAttribute("y1"));
+    arrow.endX = Number(arrowNode.getAttribute("x2"));
+    arrow.endY = Number(arrowNode.getAttribute("y2"));
+    arrow.strokeColor = arrowNode.getAttribute("stroke");
+    arrow.strokeWidth = arrowNode.getAttribute("stroke-width");
+    arrow.type = "arrow";
+    arrow.strokeStyle = SUPPORTED_SEQUENCE_ARROW_TYPES[message.type];
+    arrows.push(arrow);
   });
   return arrows;
 };

--- a/src/parser/sequence.ts
+++ b/src/parser/sequence.ts
@@ -44,8 +44,8 @@ export type Container = {
   };
   x: number;
   y: number;
-  width: number;
-  height: number;
+  width?: number;
+  height?: number;
   strokeStyle?: "dashed" | "solid";
   strokeWidth?: number;
   strokeColor?: string;
@@ -368,17 +368,21 @@ const parseLoops = (containerEl: Element) => {
     const textElement = createTextElement(node, text);
 
     texts.push(textElement);
-    const parentElement = node.parentElement;
-    const labelBox = parentElement?.querySelector(
-      ".labelBox"
-    )! as SVGSVGElement;
-    const labelText =
-      parentElement?.querySelector(".labelText")?.textContent || "";
-    const container = createContainerElement(labelBox, "rectangle", labelText);
-    container.strokeColor = "#adb5bd";
-    container.bgColor = "#e9ecef";
-    nodes.push(container);
   });
+  if (!loopText.length) {
+    return;
+  }
+  const parentElement = loopText[0].parentElement;
+  const labelBox = parentElement?.querySelector(".labelBox")! as SVGSVGElement;
+  const labelTextNode = parentElement?.querySelector(".labelText");
+  const labelText = labelTextNode?.textContent || "";
+  const container = createContainerElement(labelBox, "rectangle", labelText);
+  container.strokeColor = "#adb5bd";
+  container.bgColor = "#e9ecef";
+  // So width is calculated based on label
+  container.width = undefined;
+
+  nodes.push(container);
   return { lines, texts, nodes };
 };
 

--- a/src/parser/sequence.ts
+++ b/src/parser/sequence.ts
@@ -2,6 +2,7 @@ import { Diagram } from "mermaid/dist/Diagram.js";
 import { SVG_TO_SHAPE_MAPPER } from "../constants.js";
 import { ExcalidrawLinearElement } from "@excalidraw/excalidraw/types/element/types.js";
 import { nanoid } from "nanoid";
+import { entityCodesToText } from "../utils.js";
 
 export type Line = {
   id?: string;
@@ -160,7 +161,7 @@ const createContainerElement = (
   }
   if (text) {
     container.label = {
-      text,
+      text: entityCodesToText(text),
       fontSize: 16,
     };
   }
@@ -195,7 +196,7 @@ const createTextElement = (
   const x = Number(textNode.getAttribute("x"));
   const y = Number(textNode.getAttribute("y"));
   node.type = "text";
-  node.text = text;
+  node.text = entityCodesToText(text);
   if (opts?.id) {
     node.id = opts.id;
   }
@@ -243,9 +244,8 @@ const createArrowElement = (
   message: Message
 ) => {
   const arrow = {} as Arrow;
-  arrow.label = { text: message.message, fontSize: 16 };
+  arrow.label = { text: entityCodesToText(message.message), fontSize: 16 };
   const tagName = arrowNode.tagName;
-
   if (tagName === "line") {
     arrow.startX = Number(arrowNode.getAttribute("x1"));
     arrow.startY = Number(arrowNode.getAttribute("y1"));

--- a/src/parser/sequence.ts
+++ b/src/parser/sequence.ts
@@ -16,7 +16,7 @@ type ARROW_KEYS = keyof typeof SUPPORTED_SEQUENCE_ARROW_TYPES;
 
 export type Arrow = Line & {
   text?: string | null;
-  arrowType: (typeof SUPPORTED_SEQUENCE_ARROW_TYPES)[ARROW_KEYS];
+  strokeStyle: (typeof SUPPORTED_SEQUENCE_ARROW_TYPES)[ARROW_KEYS];
 };
 
 export interface Sequence {
@@ -113,7 +113,7 @@ const parseMessages = (messages: Message[], containerEl: Element) => {
       arrow.strokeColor = arrowNode.getAttribute("stroke");
       arrow.strokeWidth = arrowNode.getAttribute("stroke-width");
       arrow.type = "arrow";
-      arrow.arrowType = SUPPORTED_SEQUENCE_ARROW_TYPES[message.type];
+      arrow.strokeStyle = SUPPORTED_SEQUENCE_ARROW_TYPES[message.type];
       arrows.push(arrow);
     }
   });

--- a/src/parser/sequence.ts
+++ b/src/parser/sequence.ts
@@ -1,0 +1,138 @@
+import { Diagram } from "mermaid/dist/Diagram.js";
+import { Vertex } from "../interfaces.js";
+
+export type Line = {
+  id?: string;
+  startX: number;
+  startY: number;
+  endX: number;
+  endY: number;
+  strokeColor: string | null;
+  strokeWidth: string | null;
+  type: "line" | "arrow";
+};
+
+type ARROW_KEYS = keyof typeof SUPPORTED_SEQUENCE_ARROW_TYPES;
+
+export type Arrow = Line & {
+  text?: string | null;
+  arrowType: (typeof SUPPORTED_SEQUENCE_ARROW_TYPES)[ARROW_KEYS];
+};
+
+export interface Sequence {
+  type: "sequence";
+  nodes: Vertex[];
+  lines: Line[];
+  arrows: Arrow[];
+}
+
+type Message = {
+  type: ARROW_KEYS;
+  to: string;
+  from: string;
+  message: string;
+  wrap: boolean;
+};
+
+// Currently mermaid supported these 6 arrow types, the names are taken from mermaidParser.LINETYPE
+const SUPPORTED_SEQUENCE_ARROW_TYPES = {
+  0: "SOLID",
+  1: "DOTTED",
+  3: "SOLID_CROSS",
+  4: "DOTTED_CROSS",
+  6: "DOTTED_OPEN",
+  24: "SOLID_POINT",
+  25: "DOTTED_POINT",
+};
+
+const parseActor = (actors: Array<any>, containerEl: Element) => {
+  const textNodes = Array.from(containerEl.querySelectorAll(".actor")).filter(
+    (node: any) => node.tagName === "text"
+  ) as SVGSVGElement[];
+  const nodes: Vertex[] = [];
+  const lines: Array<Line> = [];
+  textNodes.forEach((textNode) => {
+    const text = textNode.textContent!;
+    const vertexNode = textNode.previousElementSibling as SVGSVGElement | null;
+    if (!vertexNode) {
+      return [];
+    }
+    const node = {} as Vertex;
+    node.text = text;
+
+    // Get dimension
+    const boundingBox = vertexNode.getBBox();
+    node.x = boundingBox.x;
+    node.y = boundingBox.y;
+    node.width = boundingBox.width;
+    node.height = boundingBox.height;
+    nodes.push(node);
+
+    const lineNode = textNode.parentElement?.parentElement
+      ?.firstChild as SVGLineElement;
+    const line = {} as Line;
+    if (lineNode?.tagName === "line") {
+      line.id = `${text}-line`;
+      line.startX = Number(lineNode.getAttribute("x1"));
+      line.startY = node.y + node.height;
+      line.endX = Number(lineNode.getAttribute("x2"));
+      line.endY = Number(lineNode.getAttribute("y2"));
+      line.strokeColor = lineNode.getAttribute("stroke");
+      line.strokeWidth = lineNode.getAttribute("stroke-width");
+      line.type = "line";
+      lines.push(line);
+    } else {
+      const lineConnectingNodes = lines.find(
+        (line) => line.id === `${text}-line`
+      );
+      // Make sure lines don't overlap with the containers, in mermaid it overlaps but isn't visible as its pushed back and containers are non transparent
+      if (lineConnectingNodes) {
+        Object.assign(lineConnectingNodes, { endY: node.y });
+      }
+    }
+  });
+
+  return { nodes, lines };
+};
+
+const parseMessages = (messages: Message[], containerEl: Element) => {
+  const arrows: Arrow[] = [];
+  const arrowNodes = Array.from(
+    containerEl.querySelectorAll('[class*="messageLine"]')
+  ) as SVGLineElement[];
+  arrowNodes.forEach((arrowNode, index) => {
+    const textNode = arrowNode.nextElementSibling as SVGTextElement | null;
+    const message = messages[index];
+    const arrow = {} as Arrow;
+    if (textNode) {
+      arrow.text = textNode.textContent;
+      arrow.startX = Number(arrowNode.getAttribute("x1"));
+      arrow.startY = Number(arrowNode.getAttribute("y1"));
+      arrow.endX = Number(arrowNode.getAttribute("x2"));
+      arrow.endY = Number(arrowNode.getAttribute("y2"));
+      arrow.strokeColor = arrowNode.getAttribute("stroke");
+      arrow.strokeWidth = arrowNode.getAttribute("stroke-width");
+      arrow.type = "arrow";
+      arrow.arrowType = SUPPORTED_SEQUENCE_ARROW_TYPES[message.type];
+      arrows.push(arrow);
+    }
+  });
+  return arrows;
+};
+
+export const parseMermaidSequenceDiagram = (
+  diagram: Diagram,
+  containerEl: Element
+): Sequence => {
+  diagram.parse();
+
+  // Get mermaid parsed data from parser shared variable `yy`
+  const mermaidParser = diagram.parser.yy;
+
+  const actorData = mermaidParser.getActors();
+  const { nodes, lines } = parseActor(actorData, containerEl);
+  const messages = mermaidParser.getMessages();
+  const arrows = parseMessages(messages, containerEl);
+  console.log("parsing", nodes, actorData.containerEl);
+  return { type: "sequence", lines, arrows, nodes };
+};

--- a/src/parser/sequence.ts
+++ b/src/parser/sequence.ts
@@ -166,10 +166,10 @@ const createLineElement = (
 
 const createArrowElement = (
   arrowNode: SVGLineElement | SVGPathElement,
-  message: string | null
+  message: Message
 ) => {
   const arrow = {} as Arrow;
-  arrow.label = { text: message, fontSize: 16 };
+  arrow.label = { text: message.message, fontSize: 16 };
   const tagName = arrowNode.tagName;
 
   if (tagName === "line") {
@@ -353,13 +353,13 @@ const parseMessages = (messages: Message[], containerEl: Element) => {
   const arrowNodes = Array.from(
     containerEl.querySelectorAll('[class*="messageLine"]')
   ) as SVGLineElement[];
-
-  const arrowMessages = Array.from(
-    containerEl.querySelectorAll('[class*="messageText"]')
-  ) as SVGTextElement[];
+  const supportedMessageTypes = Object.keys(SUPPORTED_SEQUENCE_ARROW_TYPES);
+  const arrowMessages = messages.filter((message) =>
+    supportedMessageTypes.includes(message.type.toString())
+  );
 
   arrowNodes.forEach((arrowNode, index) => {
-    const message = arrowMessages[index].textContent;
+    const message = arrowMessages[index];
     const arrow = createArrowElement(arrowNode, message);
 
     arrows.push(arrow);

--- a/src/parser/sequence.ts
+++ b/src/parser/sequence.ts
@@ -300,7 +300,10 @@ const createArrowElement = (
     !!arrowNode.nextElementSibling?.classList.contains("sequenceNumber");
 
   if (showSequenceNumber) {
-    const text = arrowNode.nextElementSibling?.textContent!;
+    const text = arrowNode.nextElementSibling?.textContent;
+    if (!text) {
+      throw new Error("sequence number not present");
+    }
     const height = 30;
     const yOffset = height / 2;
     const xOffset = 10;
@@ -377,7 +380,7 @@ const createActorSymbol = (
 const parseActor = (actors: { [key: string]: Actor }, containerEl: Element) => {
   const actorRootNodes = Array.from(containerEl.querySelectorAll(".actor"))
     .filter((node) => node.tagName === "text")
-    .map((actor) => actor.tagName === "text" && actor.parentElement)!;
+    .map((actor) => actor.tagName === "text" && actor.parentElement);
 
   const nodes: Array<Node[]> = [];
   const lines: Array<Line> = [];
@@ -452,7 +455,7 @@ const parseActor = (actors: { [key: string]: Actor }, containerEl: Element) => {
       // Make sure lines don't overlap with the nodes, in mermaid it overlaps but isn't visible as its pushed back and containers are non transparent
       const bottomEllipseNode = bottomNodeElement.find(
         (node) => node.type === "ellipse"
-      )! as Container;
+      ) as Container;
       const endY = bottomEllipseNode.y;
       const line = createLineElement(lineNode, startX, startY, endX, endY);
       lines.push(line);
@@ -565,7 +568,7 @@ const parseLoops = (messages: Message[], containerEl: Element) => {
 
   const labelBoxes = Array.from(
     containerEl?.querySelectorAll(".labelBox")
-  )! as SVGSVGElement[];
+  ) as SVGSVGElement[];
   const labelTextNode = Array.from(containerEl?.querySelectorAll(".labelText"));
 
   labelBoxes.forEach((labelBox, index) => {

--- a/src/parser/sequence.ts
+++ b/src/parser/sequence.ts
@@ -44,6 +44,8 @@ export type Container = {
   y: number;
   width: number;
   height: number;
+  strokeStyle?: "dashed" | "solid";
+  strokeWidth?: number;
 };
 export type Node = Container | Line | Arrow | Text;
 
@@ -279,6 +281,24 @@ const parseMessages = (messages: Message[], containerEl: Element) => {
   return arrows;
 };
 
+const parseNotes = (containerEl: Element) => {
+  const noteNodes = Array.from(containerEl.querySelectorAll(".note")).map(
+    (node) => node.parentElement
+  );
+  const notes: Container[] = [];
+  noteNodes.forEach((node) => {
+    if (!node) {
+      return;
+    }
+    const rect = node.firstChild as SVGSVGElement;
+    const text = node.lastChild?.textContent!;
+    const note = createContainerElement(rect, "rectangle", text);
+    note.strokeStyle = "dashed";
+    notes.push(note);
+  });
+  return notes;
+};
+
 export const parseMermaidSequenceDiagram = (
   diagram: Diagram,
   containerEl: Element
@@ -292,5 +312,7 @@ export const parseMermaidSequenceDiagram = (
   const { nodes, lines } = parseActor(actorData, containerEl);
   const messages = mermaidParser.getMessages();
   const arrows = parseMessages(messages, containerEl);
+  const notes = parseNotes(containerEl);
+  nodes.push(notes);
   return { type: "sequence", lines, arrows, nodes };
 };

--- a/src/parser/sequence.ts
+++ b/src/parser/sequence.ts
@@ -276,9 +276,13 @@ const parseMessages = (messages: Message[], containerEl: Element) => {
   const arrowNodes = Array.from(
     containerEl.querySelectorAll('[class*="messageLine"]')
   ) as SVGLineElement[];
-
+  // There are cases when messages array contains messages without
+  // from and to eg loops hence removing those cases
+  const arrowMessages = messages.filter(
+    (message) => message.from && message.to
+  );
   arrowNodes.forEach((arrowNode, index) => {
-    const message = messages[index];
+    const message = arrowMessages[index];
     const arrow = createArrowElement(arrowNode, message);
     arrows.push(arrow);
   });
@@ -331,5 +335,6 @@ export const parseMermaidSequenceDiagram = (
   const activations = parseActivations(containerEl);
   nodes.push(notes);
   nodes.push(activations);
+  console.log(mermaidParser, "meramid");
   return { type: "sequence", lines, arrows, nodes };
 };

--- a/src/parser/sequence.ts
+++ b/src/parser/sequence.ts
@@ -40,6 +40,7 @@ const SUPPORTED_SEQUENCE_ARROW_TYPES = {
   1: "DOTTED",
   3: "SOLID_CROSS",
   4: "DOTTED_CROSS",
+  5: "SOLID_OPEN",
   6: "DOTTED_OPEN",
   24: "SOLID_POINT",
   25: "DOTTED_POINT",
@@ -133,6 +134,6 @@ export const parseMermaidSequenceDiagram = (
   const { nodes, lines } = parseActor(actorData, containerEl);
   const messages = mermaidParser.getMessages();
   const arrows = parseMessages(messages, containerEl);
-  console.log("parsing", nodes, actorData.containerEl);
+  console.log("parsing", mermaidParser.LINETYPE, messages);
   return { type: "sequence", lines, arrows, nodes };
 };

--- a/src/parser/sequence.ts
+++ b/src/parser/sequence.ts
@@ -65,7 +65,7 @@ export interface Sequence {
   nodes: Array<Node[]>;
   lines: Line[];
   arrows: Arrow[];
-  loops: Loop;
+  loops: Loop | undefined;
 }
 
 type Message = {
@@ -153,10 +153,10 @@ const createLineElement = (
 
 const createArrowElement = (
   arrowNode: SVGLineElement | SVGPathElement,
-  message: Message
+  message: string | null
 ) => {
   const arrow = {} as Arrow;
-  arrow.label = { text: message.message, fontSize: 16 };
+  arrow.label = { text: message, fontSize: 16 };
   const tagName = arrowNode.tagName;
 
   if (tagName === "line") {
@@ -198,7 +198,7 @@ const createArrowElement = (
     arrow.endY = endPosition[1];
     arrow.points = points;
   }
-  if (message.message) {
+  if (message) {
     // In mermaid the text is positioned above arrow but in Excalidraw
     // its postioned on the arrow hence the elements below it might look cluttered so shifting the arrow by an offset of 10px
     const offset = 10;
@@ -341,13 +341,12 @@ const parseMessages = (messages: Message[], containerEl: Element) => {
     containerEl.querySelectorAll('[class*="messageLine"]')
   ) as SVGLineElement[];
 
-  // There are cases when messages array contains messages without
-  // from and to eg loops hence removing those cases
-  const arrowMessages = messages.filter(
-    (message) => message.from && message.to
-  );
+  const arrowMessages = Array.from(
+    containerEl.querySelectorAll('[class*="messageText"]')
+  ) as SVGTextElement[];
+
   arrowNodes.forEach((arrowNode, index) => {
-    const message = arrowMessages[index];
+    const message = arrowMessages[index].textContent;
     const arrow = createArrowElement(arrowNode, message);
 
     arrows.push(arrow);
@@ -372,6 +371,7 @@ const parseNotes = (containerEl: Element) => {
   });
   return notes;
 };
+
 const parseActivations = (containerEl: Element) => {
   const activationNodes = Array.from(
     containerEl.querySelectorAll(`[class*=activation]`)

--- a/src/parser/sequence.ts
+++ b/src/parser/sequence.ts
@@ -452,7 +452,7 @@ const parseActor = (actors: { [key: string]: Actor }, containerEl: Element) => {
       // Make sure lines don't overlap with the nodes, in mermaid it overlaps but isn't visible as its pushed back and containers are non transparent
       const bottomEllipseNode = bottomNodeElement.find(
         (node) => node.type === "ellipse"
-      )!;
+      )! as Container;
       const endY = bottomEllipseNode.y;
       const line = createLineElement(lineNode, startX, startY, endX, endY);
       lines.push(line);
@@ -464,7 +464,6 @@ const parseActor = (actors: { [key: string]: Actor }, containerEl: Element) => {
 
 const computeArrows = (messages: Message[], containerEl: Element) => {
   const arrows: Arrow[] = [];
-  const sequenceNumbers: Container[] = [];
 
   const arrowNodes = Array.from(
     containerEl.querySelectorAll('[class*="messageLine"]')

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -9,6 +9,7 @@ export const isSupportedDiagram = (definition: string): boolean => {
 
 // Convert mermaid entity codes to text e.g. "#9829;" to "♥"
 export const entityCodesToText = (input: string): string => {
+  input = decodeEntities(input);
   const modifiedInput = input
     .replace(/#(\d+);/g, "&#$1;")
     .replace(/#([a-z]+);/g, "&$1;");
@@ -29,4 +30,32 @@ export const getTransformAttr = (el: Element) => {
     transformY = Number(translateMatch[2]);
   }
   return { transformX, transformY };
+};
+
+//TODO Once fixed in mermaid this will be removed
+export const encodeEntities = (text: string) => {
+  let txt = text;
+
+  txt = txt.replace(/style.*:\S*#.*;/g, (s) => {
+    return s.substring(0, s.length - 1);
+  });
+  txt = txt.replace(/classDef.*:\S*#.*;/g, (s) => {
+    return s.substring(0, s.length - 1);
+  });
+
+  txt = txt.replace(/#\w+;/g, (s) => {
+    const innerTxt = s.substring(1, s.length - 1);
+
+    const isInt = /^\+?\d+$/.test(innerTxt);
+    if (isInt) {
+      return `ﬂ°°${innerTxt}¶ß`;
+    }
+    return `ﬂ°${innerTxt}¶ß`;
+  });
+
+  return txt;
+};
+
+export const decodeEntities = function (text: string): string {
+  return text.replace(/ﬂ°°/g, "#").replace(/ﬂ°/g, "&").replace(/¶ß/g, ";");
 };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,12 +1,3 @@
-import { SUPPORTED_DIAGRAM_TYPES } from "./constants.js";
-
-// Check if the definition is a supported diagram
-export const isSupportedDiagram = (definition: string): boolean => {
-  return SUPPORTED_DIAGRAM_TYPES.some((chartType) =>
-    definition.trim().startsWith(chartType)
-  );
-};
-
 // Convert mermaid entity codes to text e.g. "#9829;" to "♥"
 export const entityCodesToText = (input: string): string => {
   input = decodeEntities(input);

--- a/yarn.lock
+++ b/yarn.lock
@@ -883,10 +883,10 @@
   resolved "https://registry.yarnpkg.com/@excalidraw/eslint-config/-/eslint-config-1.0.3.tgz#2122ef7413ae77874ae9848ce0f1c6b3f0d8bbbd"
   integrity sha512-GemHNF5Z6ga0BWBSX7GJaNBUchLu6RwTcAB84eX1MeckRNhNasAsPCdelDlFalz27iS4RuYEQh0bPE8SRxJgbQ==
 
-"@excalidraw/excalidraw@0.16.1-6920-3a6028b":
-  version "0.16.1-6920-3a6028b"
-  resolved "https://registry.yarnpkg.com/@excalidraw/excalidraw/-/excalidraw-0.16.1-6920-3a6028b.tgz#88b329cade4896ada56ca7f1bc7595adf554e868"
-  integrity sha512-DpfAJXNoZiFgQdZyMAor46UEG5eSpkTLHTXeUcTpsw22b+UC0CeSaKyESxzsE6nA1BxzqsrLNJTuPFUVi0aL+A==
+"@excalidraw/excalidraw@0.16.1-6920-d3d0bd0":
+  version "0.16.1-6920-d3d0bd0"
+  resolved "https://registry.yarnpkg.com/@excalidraw/excalidraw/-/excalidraw-0.16.1-6920-d3d0bd0.tgz#78f682c6b770650d7f6f2d662f5a41e3ea2775f8"
+  integrity sha512-VfDa+YzGdkZt+aMrkMJg5e5CbuAFEFs+Sel3/KD6A4xne+lRQsOIrsFk71OGfcasfB7jwyEYR54p3S440VoZfA==
 
 "@excalidraw/markdown-to-text@0.1.2":
   version "0.1.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -883,10 +883,10 @@
   resolved "https://registry.yarnpkg.com/@excalidraw/eslint-config/-/eslint-config-1.0.3.tgz#2122ef7413ae77874ae9848ce0f1c6b3f0d8bbbd"
   integrity sha512-GemHNF5Z6ga0BWBSX7GJaNBUchLu6RwTcAB84eX1MeckRNhNasAsPCdelDlFalz27iS4RuYEQh0bPE8SRxJgbQ==
 
-"@excalidraw/excalidraw@0.16.0":
-  version "0.16.0"
-  resolved "https://registry.yarnpkg.com/@excalidraw/excalidraw/-/excalidraw-0.16.0.tgz#502ac37ab9599c3a0151faeac743655d6b4c5ed6"
-  integrity sha512-9DGTKBWs1MPA6FbBg443Q77qGYeNJIyDWoQWVEMG2NsMfHHot8I5zM4jXvi9Eb31n8BqA1jqGhF8E9FVeprMOA==
+"@excalidraw/excalidraw@0.16.1-6920-3a6028b":
+  version "0.16.1-6920-3a6028b"
+  resolved "https://registry.yarnpkg.com/@excalidraw/excalidraw/-/excalidraw-0.16.1-6920-3a6028b.tgz#88b329cade4896ada56ca7f1bc7595adf554e868"
+  integrity sha512-DpfAJXNoZiFgQdZyMAor46UEG5eSpkTLHTXeUcTpsw22b+UC0CeSaKyESxzsE6nA1BxzqsrLNJTuPFUVi0aL+A==
 
 "@excalidraw/markdown-to-text@0.1.2":
   version "0.1.2"


### PR DESCRIPTION
Support Mermaid [Sequence diagrams](https://mermaid.js.org/syntax/sequenceDiagram.html#sequence-diagrams)
- [x] Support name and definition in testcases and beautify playground
- [x] Support containers, arrows and lines
- [x] transform the arrow type to correct excalidraw stroke style
- [x] don't show arrow head for solid open and dotted open
- [x] Render actors symbols in Excalidraw when present
![image](https://github.com/excalidraw/mermaid-to-excalidraw/assets/11256141/d2e171de-9469-45aa-b40a-85d52442a657)
- [x] Grouping
- [x] Support grouping/box when diagram includes actor symbols
- [x] group actor image elements so it easy to move them
- [x] Aliases
```
sequenceDiagram
    participant A as Alice
    participant J as John
    A->>J: Hello John, how are you?
    J->>A: Great!
```
- [x] Notes
- [x] Add test cases for sequence
- [x] clean up playground
- [x] Activations
- [x] Loops
- [x] Alternate Paths
- [x] Parallel Actions
- [x] Breaks
- [x] Critical Regions
- [x] Self loops
- [x] Comments
- [x] Sequence numbers
- [x] background highlights
- [x] critical label shouldn't overlap with loop text
- [x] Remove font customization as Mermaid breaks with customizing font
![image](https://github.com/excalidraw/mermaid-to-excalidraw/assets/11256141/4c3c985a-b8ed-44d6-bb8d-ea3c4d8e9ad7)

- [x] Entity codes to escape characters

I use the API `diagram.parser.yy.getMessages` and the text gets removed in this API when it containes entity codes (https://github.com/mermaid-js/mermaid/issues/4983). So this API needs to be fixed in mermaid package. I can add a hacky fix rn to support it but will prefer using the message API to reduce the dependency on DOM. Opened a PR - https://github.com/mermaid-js/mermaid/pull/5002. 
Right now I have added the support in this PR by handling entity codes. Once PR is merged that part will be removed

## Unsupported Features
*  **Actor Creation and Destruction** 
For this we have to upgrade to at least 10.3.0 as this is supported 10.3.0 onwards, however the SVG nodes order is reversed which is making this upgrade trickier, more info here - https://github.com/mermaid-js/mermaid/issues/4946
* **Entity codes to escape characters**
~I use the API `diagram.parser.yy.getMessages` and the text gets removed in this API when it containes entity codes (https://github.com/mermaid-js/mermaid/issues/4983). So this API needs to be fixed in mermaid package. I can add a hacky fix rn to support it but will prefer using the message API to reduce the dependency on DOM.~
Opened a PR - https://github.com/mermaid-js/mermaid/pull/5002 and have added support in this PR as well
* **Actor menus**
They don't work on mermaid itself - https://github.com/mermaid-js/mermaid/issues/4212


