### PR TITLE
fix: clear parcel cache before starting dev server

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "type": "module",
   "scripts": {
     "build": "rm -rf ./dist && tsc -b src",
-    "start": "parcel playground/index.html --open --dist-dir ./public",
+    "start": "rm -rf .parcel-cache && parcel playground/index.html --open --dist-dir ./public",
     "build:playground": "rm -rf ./public && parcel build playground/index.html --no-scope-hoist --dist-dir ./public --public-url /",
     "test:code": "eslint --max-warnings=0 --ext .js,.ts,.tsx ."
   },


### PR DESCRIPTION
Every time there is some change in package.json dependencies, we need to burst parcel cache hence its better we add it in `yarn start` script itself so this is taken care.