### PR TITLE
fix: normalize text when transforming to excalidraw skeleton

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Fixes
 
+- Normalize text when transforming to excalidraw skeleton #[54](https://github.com/excalidraw/mermaid-to-excalidraw/pull/54) by [@ad1992](https://github.com/ad1992).
+
 - Render class diagrams correctly by using data-id instead dom id [#53](https://github.com/excalidraw/mermaid-to-excalidraw/pull/53) by [@ad1992](https://github.com/ad1992).
 
 ## 0.3.0 (2023-12-10)

--- a/src/converter/transformToExcalidrawSkeleton.ts
+++ b/src/converter/transformToExcalidrawSkeleton.ts
@@ -1,6 +1,10 @@
 import { ExcalidrawElementSkeleton } from "@excalidraw/excalidraw/types/data/transform.js";
 import { Arrow, Line, Node, Text } from "../elementSkeleton.js";
 
+export const normalizeText = (text: string) => {
+  return text.replace(/\\n/g, "\n");
+};
+
 export const transformToExcalidrawLineSkeleton = (line: Line) => {
   const lineElement: ExcalidrawElementSkeleton = {
     type: "line",
@@ -32,7 +36,7 @@ export const transformToExcalidrawTextSkeleton = (element: Text) => {
     y: element.y,
     width: element.width,
     height: element.height,
-    text: element.text || "",
+    text: normalizeText(element.text) || "",
     fontSize: element.fontSize,
     verticalAlign: "middle",
   };
@@ -63,7 +67,7 @@ export const transformToExcalidrawContainerSkeleton = (
     width: element.width,
     height: element.height,
     label: {
-      text: element?.label?.text || "",
+      text: normalizeText(element?.label?.text || ""),
       fontSize: element?.label?.fontSize,
       verticalAlign: element.label?.verticalAlign || "middle",
       strokeColor: element.label?.color || "#000",
@@ -98,7 +102,7 @@ export const transformToExcalidrawArrowSkeleton = (arrow: Arrow) => {
     endArrowhead: arrow?.endArrowhead || null,
     startArrowhead: arrow?.startArrowhead || null,
     label: {
-      text: arrow?.label?.text || "",
+      text: normalizeText(arrow?.label?.text || ""),
       fontSize: 16,
     },
     roundness: {


### PR DESCRIPTION
closes #47 