### PR TITLE
[wip] feat: support state diagram

### DIFF
--- a/playground/SingleTestCase.tsx
+++ b/playground/SingleTestCase.tsx
@@ -1,7 +1,7 @@
 import { MermaidDiagram } from "./MermaidDiagram";
 
 export interface TestCase {
-  type: "class" | "flowchart" | "sequence" | "unsupported";
+  type: "class" | "flowchart" | "sequence" | "unsupported" | "state";
   name: string;
   definition: string;
 }

--- a/playground/Testcases.tsx
+++ b/playground/Testcases.tsx
@@ -2,6 +2,7 @@ import { Fragment } from "react";
 
 import { FLOWCHART_DIAGRAM_TESTCASES } from "./testcases/flowchart";
 import { SEQUENCE_DIAGRAM_TESTCASES } from "./testcases/sequence.ts";
+import { STATE_DIAGRAM_TESTCASES } from "./testcases/state.ts";
 import { CLASS_DIAGRAM_TESTCASES } from "./testcases/class.ts";
 import { UNSUPPORTED_DIAGRAM_TESTCASES } from "./testcases/unsupported.ts";
 
@@ -18,6 +19,7 @@ interface TestcasesProps {
 
 const Testcases = ({ onChange }: TestcasesProps) => {
   const testcaseTypes: { name: string; testcases: TestCase[] }[] = [
+    { name: "State", testcases: STATE_DIAGRAM_TESTCASES },
     { name: "Flowchart", testcases: FLOWCHART_DIAGRAM_TESTCASES },
     { name: "Sequence", testcases: SEQUENCE_DIAGRAM_TESTCASES },
     { name: "Class", testcases: CLASS_DIAGRAM_TESTCASES },

--- a/playground/testcases/state.ts
+++ b/playground/testcases/state.ts
@@ -247,6 +247,29 @@ export const STATE_DIAGRAM_TESTCASES: TestCase[] = [
     type: "state",
   },
   {
+    name: "Styling",
+    definition: `stateDiagram-v2
+   direction TB
+
+   classDef notMoving fill:white
+   classDef movement font-style:italic
+   classDef badBadEvent fill:#f00,color:white,font-weight:bold,stroke-width:2px,stroke:yellow
+
+   [*]--> Still
+   Still --> [*]
+   Still --> Moving
+   Moving --> Still
+   Moving --> Crash
+   Crash --> [*]
+
+   class Still notMoving
+   class Moving, Crash movement
+   class Crash badBadEvent
+   class end badBadEvent
+`,
+    type: "state",
+  },
+  {
     name: "Sample 1",
     definition: `stateDiagram-v2
     [*] --> Still

--- a/playground/testcases/state.ts
+++ b/playground/testcases/state.ts
@@ -44,4 +44,15 @@ export const STATE_DIAGRAM_TESTCASES: TestCase[] = [
         `,
     type: "state",
   },
+  {
+    name: "Sample 1",
+    definition: `stateDiagram-v2
+    [*] --> Still
+    Still --> [*]
+    Still --> Moving
+    Moving --> Still
+    Moving --> Crash
+    Crash --> [*]
+    `,
+  },
 ];

--- a/playground/testcases/state.ts
+++ b/playground/testcases/state.ts
@@ -73,7 +73,7 @@ export const STATE_DIAGRAM_TESTCASES: TestCase[] = [
             }
         }
     }
-  `,
+`,
     type: "state",
   },
   {
@@ -95,7 +95,7 @@ export const STATE_DIAGRAM_TESTCASES: TestCase[] = [
         [*] --> thi
         thi --> [*]
     }
-    `,
+`,
     type: "state",
   },
   {
@@ -110,7 +110,46 @@ export const STATE_DIAGRAM_TESTCASES: TestCase[] = [
         [*] --> second
         second --> [*]
     }
-  `,
+`,
+    type: "state",
+  },
+  {
+    name: "Choice",
+    definition: `stateDiagram-v2
+    state if_state <<choice>>
+    [*] --> IsPositive
+    IsPositive --> if_state
+    if_state --> False: if n < 0
+    if_state --> True : if n >= 0
+`,
+    type: "state",
+  },
+  {
+    name: "Choice in a composite state",
+    definition: `stateDiagram-v2
+    [*] --> First
+    First --> Second
+    First --> Third
+
+    state First {
+        [*] --> fir
+        fir --> [*]
+        
+        state if_state <<choice>>
+        [*] --> IsPositive
+        IsPositive --> if_state
+        if_state --> False: if n < 0
+        if_state --> True : if n >= 0
+    }
+    state Second {
+        [*] --> sec
+        sec --> [*]
+    }
+    state Third {
+        [*] --> thi
+        thi --> [*]
+    }
+`,
     type: "state",
   },
   {

--- a/playground/testcases/state.ts
+++ b/playground/testcases/state.ts
@@ -154,6 +154,22 @@ export const STATE_DIAGRAM_TESTCASES: TestCase[] = [
   },
 
   {
+    name: "Forks",
+    definition: `stateDiagram-v2
+    state fork_state <<fork>>
+    fork_state --> State2
+    fork_state --> State3
+    [*] --> fork_state
+    
+    state join_state <<join>>
+    State2 --> join_state
+    State3 --> join_state
+    join_state --> State4
+    State4 --> [*]
+`,
+    type: "state",
+  },
+  {
     name: "Notes",
     definition: `stateDiagram-v2
     State1: The state with a note

--- a/playground/testcases/state.ts
+++ b/playground/testcases/state.ts
@@ -152,6 +152,63 @@ export const STATE_DIAGRAM_TESTCASES: TestCase[] = [
 `,
     type: "state",
   },
+
+  {
+    name: "Notes",
+    definition: `stateDiagram-v2
+    State1: The state with a note
+    note right of State1
+        Important information! You can write
+        notes.
+    end note
+    State1 --> State2
+    note left of State2 : This is the note to the left.
+`,
+    type: "state",
+  },
+  {
+    name: "Note left and right in same state",
+    definition: `stateDiagram-v2
+    State1: The state with a note
+    note right of State1
+        Important information! You can write
+        notes.
+    end note
+    note left of State1 : This is the note to the left.
+`,
+    type: "state",
+  },
+  {
+    name: "Multiple notes in the same state",
+    definition: `stateDiagram-v2
+    State1: The state with a note
+    note right of State1
+        Important information! You can write
+        notes.
+    end note
+    note left of State1 : Left.
+    note left of State1 : Join.
+    note left of State1 : Out.
+    note right of State1 : Ok!.
+`,
+    type: "state",
+  },
+  {
+    name: "Notes inside a composite state",
+    definition: `stateDiagram-v2
+    [*] --> First
+    state First {
+        [*] --> second
+        second --> [*]
+
+        note right of second
+        First is a composite state
+        end note
+  
+    }
+`,
+    type: "state",
+  },
   {
     name: "Sample 1",
     definition: `stateDiagram-v2

--- a/playground/testcases/state.ts
+++ b/playground/testcases/state.ts
@@ -226,6 +226,27 @@ export const STATE_DIAGRAM_TESTCASES: TestCase[] = [
     type: "state",
   },
   {
+    name: "Concurrency",
+    definition: `stateDiagram-v2
+      [*] --> Active
+
+      state Active {
+          [*] --> NumLockOff
+          NumLockOff --> NumLockOn : EvNumLockPressed
+          NumLockOn --> NumLockOff : EvNumLockPressed
+          --
+          [*] --> CapsLockOff
+          CapsLockOff --> CapsLockOn : EvCapsLockPressed
+          CapsLockOn --> CapsLockOff : EvCapsLockPressed
+          --
+          [*] --> ScrollLockOff
+          ScrollLockOff --> ScrollLockOn : EvScrollLockPressed
+          ScrollLockOn --> ScrollLockOff : EvScrollLockPressed
+      }
+  `,
+    type: "state",
+  },
+  {
     name: "Sample 1",
     definition: `stateDiagram-v2
     [*] --> Still

--- a/playground/testcases/state.ts
+++ b/playground/testcases/state.ts
@@ -5,35 +5,35 @@ export const STATE_DIAGRAM_TESTCASES: TestCase[] = [
     name: "Declare a state with just an id",
     definition: `stateDiagram-v2
     Stateid
-    `,
+`,
     type: "state",
   },
   {
     name: "Declare a state with description",
     definition: `stateDiagram-v2
     state "This is a state description" as s2
-    `,
+`,
     type: "state",
   },
   {
     name: "Declare a state with description using another syntax",
     definition: `stateDiagram-v2
     s2 : This is a state description
-    `,
+`,
     type: "state",
   },
   {
     name: "Simple Transition",
     definition: `stateDiagram-v2
     s1 --> s2
-    `,
+`,
     type: "state",
   },
   {
     name: "Simple transition with a text",
     definition: `stateDiagram-v2
     s1 --> s2: Transition Description
-    `,
+`,
     type: "state",
   },
   {
@@ -41,7 +41,76 @@ export const STATE_DIAGRAM_TESTCASES: TestCase[] = [
     definition: `stateDiagram-v2
         [*] --> s1
         s1 --> [*]
-        `,
+`,
+    type: "state",
+  },
+  {
+    name: "Composite states ",
+    definition: `stateDiagram-v2
+    [*] --> First
+    state First {
+        [*] --> second
+        second --> [*]
+    }
+  `,
+    type: "state",
+  },
+  {
+    name: "Composite states in deep layers",
+    definition: `stateDiagram-v2
+    [*] --> First
+
+    state First {
+        [*] --> Second
+
+        state Second {
+            [*] --> second
+            second --> Third
+
+            state Third {
+                [*] --> third
+                third --> [*]
+            }
+        }
+    }
+  `,
+    type: "state",
+  },
+  {
+    name: "Transition between composite states",
+    definition: `stateDiagram-v2
+    [*] --> First
+    First --> Second
+    First --> Third
+
+    state First {
+        [*] --> fir
+        fir --> [*]
+    }
+    state Second {
+        [*] --> sec
+        sec --> [*]
+    }
+    state Third {
+        [*] --> thi
+        thi --> [*]
+    }
+    `,
+    type: "state",
+  },
+  {
+    name: "Edge case when two composite states are connected by the same state",
+    definition: `stateDiagram-v2
+    [*] --> First
+    state First {
+        [*] --> second
+        second --> [*]
+    }
+    state Second {
+        [*] --> second
+        second --> [*]
+    }
+  `,
     type: "state",
   },
   {
@@ -53,6 +122,7 @@ export const STATE_DIAGRAM_TESTCASES: TestCase[] = [
     Moving --> Still
     Moving --> Crash
     Crash --> [*]
-    `,
+  `,
+    type: "state",
   },
 ];

--- a/playground/testcases/state.ts
+++ b/playground/testcases/state.ts
@@ -1,0 +1,12 @@
+import type { TestCase } from "../SingleTestCase";
+
+export const STATE_DIAGRAM_TESTCASES: TestCase[] = [
+  {
+    name: "Start and End ",
+    definition: `stateDiagram-v2
+        [*] --> s1
+        s1 --> [*]
+        `,
+    type: "state",
+  },
+];

--- a/playground/testcases/state.ts
+++ b/playground/testcases/state.ts
@@ -2,6 +2,41 @@ import type { TestCase } from "../SingleTestCase";
 
 export const STATE_DIAGRAM_TESTCASES: TestCase[] = [
   {
+    name: "Declare a state with just an id",
+    definition: `stateDiagram-v2
+    Stateid
+    `,
+    type: "state",
+  },
+  {
+    name: "Declare a state with description",
+    definition: `stateDiagram-v2
+    state "This is a state description" as s2
+    `,
+    type: "state",
+  },
+  {
+    name: "Declare a state with description using another syntax",
+    definition: `stateDiagram-v2
+    s2 : This is a state description
+    `,
+    type: "state",
+  },
+  {
+    name: "Simple Transition",
+    definition: `stateDiagram-v2
+    s1 --> s2
+    `,
+    type: "state",
+  },
+  {
+    name: "Simple transition with a text",
+    definition: `stateDiagram-v2
+    s1 --> s2: Transition Description
+    `,
+    type: "state",
+  },
+  {
     name: "Start and End ",
     definition: `stateDiagram-v2
         [*] --> s1

--- a/src/converter/types/state.ts
+++ b/src/converter/types/state.ts
@@ -13,8 +13,12 @@ export const StateToExcalidrawSkeletonConvertor = new GraphConverter({
   converter: (chart: State) => {
     const elements: ExcalidrawElementSkeleton[] = [];
 
-    chart.nodes.forEach((firstState) => {
-      const element = transformToExcalidrawContainerSkeleton(firstState);
+    chart.nodes.forEach((node) => {
+      const element = transformToExcalidrawContainerSkeleton(node);
+
+      Object.assign(element, {
+        roundness: { type: 3 },
+      });
 
       elements.push(element);
     });
@@ -39,10 +43,12 @@ export const StateToExcalidrawSkeletonConvertor = new GraphConverter({
       }
 
       arrow.start = {
-        id: startVertex?.id || "",
+        id: startVertex.id,
+        type: "rectangle",
       };
       arrow.end = {
-        id: endVertex?.id || "",
+        id: endVertex.id,
+        type: "rectangle",
       };
 
       elements.push(transformToExcalidrawArrowSkeleton(arrow));

--- a/src/converter/types/state.ts
+++ b/src/converter/types/state.ts
@@ -17,6 +17,8 @@ export const StateToExcalidrawSkeletonConvertor = new GraphConverter({
     const elements: ExcalidrawElementSkeleton[] = [];
 
     chart.nodes.forEach((node) => {
+      const groupIds = node.groupId?.split(", ");
+
       switch (node.type) {
         case "ellipse":
         case "diamond":
@@ -29,10 +31,27 @@ export const StateToExcalidrawSkeletonConvertor = new GraphConverter({
             });
           }
 
+          if (node.groupId) {
+            Object.assign(element, {
+              label: {
+                ...element.label,
+                groupIds,
+              },
+              groupIds,
+            });
+          }
+
           elements.push(element);
           break;
         case "line":
           const line = transformToExcalidrawLineSkeleton(node);
+
+          if (node.groupId) {
+            Object.assign(line, {
+              groupIds,
+            });
+          }
+
           elements.push(line);
           break;
         case "text":
@@ -67,6 +86,8 @@ export const StateToExcalidrawSkeletonConvertor = new GraphConverter({
         return;
       }
 
+      const groupIds = edge.groupId?.split(", ");
+
       if (endVertex.id?.includes("note") || startVertex.id?.includes("note")) {
         arrow.endArrowhead = null;
         arrow.strokeStyle = "dashed";
@@ -81,7 +102,15 @@ export const StateToExcalidrawSkeletonConvertor = new GraphConverter({
         type: "rectangle",
       };
 
-      elements.push(transformToExcalidrawArrowSkeleton(arrow));
+      const arrowSkeleton = transformToExcalidrawArrowSkeleton(arrow);
+
+      if (groupIds) {
+        Object.assign(arrowSkeleton, {
+          groupIds,
+        });
+      }
+
+      elements.push(arrowSkeleton);
     });
 
     return { elements };

--- a/src/converter/types/state.ts
+++ b/src/converter/types/state.ts
@@ -23,7 +23,7 @@ export const StateToExcalidrawSkeletonConvertor = new GraphConverter({
         case "rectangle":
           const element = transformToExcalidrawContainerSkeleton(node);
 
-          if (!element.id?.includes("note")) {
+          if (node?.subtype !== "note") {
             Object.assign(element, {
               roundness: { type: 3 },
             });

--- a/src/converter/types/state.ts
+++ b/src/converter/types/state.ts
@@ -8,6 +8,7 @@ import {
 
 import type { State } from "../../parser/state.js";
 import type { Arrow } from "../../elementSkeleton.js";
+import type { Point } from "@excalidraw/excalidraw/types/types.js";
 
 export const StateToExcalidrawSkeletonConvertor = new GraphConverter({
   converter: (chart: State) => {
@@ -24,14 +25,14 @@ export const StateToExcalidrawSkeletonConvertor = new GraphConverter({
     });
 
     chart.edges.forEach((edge) => {
-      const points = edge.reflectionPoints.map((point) => [
+      const points = edge.reflectionPoints.map((point: Point) => [
         point.x - edge.reflectionPoints[0].x,
         point.y - edge.reflectionPoints[0].y,
       ]);
 
       const arrow: Arrow = {
         ...edge,
-        endArrowhead: "arrow",
+        endArrowhead: "triangle",
         points,
       };
 

--- a/src/converter/types/state.ts
+++ b/src/converter/types/state.ts
@@ -1,0 +1,53 @@
+import type { ExcalidrawElementSkeleton } from "@excalidraw/excalidraw/types/data/transform.js";
+
+import { GraphConverter } from "../GraphConverter.js";
+import {
+  transformToExcalidrawContainerSkeleton,
+  transformToExcalidrawArrowSkeleton,
+} from "../transformToExcalidrawSkeleton.js";
+
+import type { State } from "../../parser/state.js";
+import type { Arrow } from "../../elementSkeleton.js";
+
+export const StateToExcalidrawSkeletonConvertor = new GraphConverter({
+  converter: (chart: State) => {
+    const elements: ExcalidrawElementSkeleton[] = [];
+
+    chart.nodes.forEach((firstState) => {
+      const element = transformToExcalidrawContainerSkeleton(firstState);
+
+      elements.push(element);
+    });
+
+    chart.edges.forEach((edge) => {
+      const points = edge.reflectionPoints.map((point) => [
+        point.x - edge.reflectionPoints[0].x,
+        point.y - edge.reflectionPoints[0].y,
+      ]);
+
+      const arrow: Arrow = {
+        ...edge,
+        endArrowhead: "arrow",
+        points,
+      };
+
+      const startVertex = elements.find((e) => e.id === edge.start);
+      const endVertex = elements.find((e) => e.id === edge.end);
+
+      if (!startVertex || !endVertex) {
+        return;
+      }
+
+      arrow.start = {
+        id: startVertex?.id || "",
+      };
+      arrow.end = {
+        id: endVertex?.id || "",
+      };
+
+      elements.push(transformToExcalidrawArrowSkeleton(arrow));
+    });
+
+    return { elements };
+  },
+});

--- a/src/converter/types/state.ts
+++ b/src/converter/types/state.ts
@@ -19,6 +19,7 @@ export const StateToExcalidrawSkeletonConvertor = new GraphConverter({
     chart.nodes.forEach((node) => {
       switch (node.type) {
         case "ellipse":
+        case "diamond":
         case "rectangle":
           const element = transformToExcalidrawContainerSkeleton(node);
 

--- a/src/converter/types/state.ts
+++ b/src/converter/types/state.ts
@@ -23,9 +23,11 @@ export const StateToExcalidrawSkeletonConvertor = new GraphConverter({
         case "rectangle":
           const element = transformToExcalidrawContainerSkeleton(node);
 
-          Object.assign(element, {
-            roundness: { type: 3 },
-          });
+          if (!element.id?.includes("note")) {
+            Object.assign(element, {
+              roundness: { type: 3 },
+            });
+          }
 
           elements.push(element);
           break;
@@ -43,6 +45,10 @@ export const StateToExcalidrawSkeletonConvertor = new GraphConverter({
     });
 
     chart.edges.forEach((edge) => {
+      if (!edge) {
+        return;
+      }
+
       const points = edge.reflectionPoints.map((point: Point) => [
         point.x - edge.reflectionPoints[0].x,
         point.y - edge.reflectionPoints[0].y,
@@ -59,6 +65,11 @@ export const StateToExcalidrawSkeletonConvertor = new GraphConverter({
 
       if (!startVertex || !endVertex) {
         return;
+      }
+
+      if (endVertex.id?.includes("note") || startVertex.id?.includes("note")) {
+        arrow.endArrowhead = null;
+        arrow.strokeStyle = "dashed";
       }
 
       arrow.start = {

--- a/src/converter/types/state.ts
+++ b/src/converter/types/state.ts
@@ -4,6 +4,8 @@ import { GraphConverter } from "../GraphConverter.js";
 import {
   transformToExcalidrawContainerSkeleton,
   transformToExcalidrawArrowSkeleton,
+  transformToExcalidrawTextSkeleton,
+  transformToExcalidrawLineSkeleton,
 } from "../transformToExcalidrawSkeleton.js";
 
 import type { State } from "../../parser/state.js";
@@ -15,13 +17,28 @@ export const StateToExcalidrawSkeletonConvertor = new GraphConverter({
     const elements: ExcalidrawElementSkeleton[] = [];
 
     chart.nodes.forEach((node) => {
-      const element = transformToExcalidrawContainerSkeleton(node);
+      switch (node.type) {
+        case "ellipse":
+        case "rectangle":
+          const element = transformToExcalidrawContainerSkeleton(node);
 
-      Object.assign(element, {
-        roundness: { type: 3 },
-      });
+          Object.assign(element, {
+            roundness: { type: 3 },
+          });
 
-      elements.push(element);
+          elements.push(element);
+          break;
+        case "line":
+          const line = transformToExcalidrawLineSkeleton(node);
+          elements.push(line);
+          break;
+        case "text":
+          const text = transformToExcalidrawTextSkeleton(node);
+          elements.push(text);
+          break;
+        default:
+          throw `unknown type ${node.type}`;
+      }
     });
 
     chart.edges.forEach((edge) => {

--- a/src/elementSkeleton.ts
+++ b/src/elementSkeleton.ts
@@ -47,7 +47,7 @@ export type Text = {
 };
 
 export type Container = {
-  type: "rectangle" | "ellipse";
+  type: "rectangle" | "ellipse" | "diamond";
   x: number;
   y: number;
   id?: string;

--- a/src/elementSkeleton.ts
+++ b/src/elementSkeleton.ts
@@ -227,7 +227,7 @@ export const createTextSkeletonFromSVG = (
 };
 
 export const createContainerSkeletonFromSVG = (
-  node: SVGSVGElement | SVGRectElement,
+  node: SVGSVGElement | SVGRectElement | SVGCircleElement,
   type: Container["type"],
   opts: {
     id?: string;

--- a/src/graphToExcalidraw.ts
+++ b/src/graphToExcalidraw.ts
@@ -6,10 +6,12 @@ import { SequenceToExcalidrawSkeletonConvertor } from "./converter/types/sequenc
 import { Sequence } from "./parser/sequence.js";
 import { Flowchart } from "./parser/flowchart.js";
 import { Class } from "./parser/class.js";
+import { State } from "./parser/state.js";
 import { classToExcalidrawSkeletonConvertor } from "./converter/types/class.js";
+import { StateToExcalidrawSkeletonConvertor } from "./converter/types/state.js";
 
 export const graphToExcalidraw = (
-  graph: Flowchart | GraphImage | Sequence | Class,
+  graph: Flowchart | GraphImage | Sequence | Class | State,
   options: MermaidOptions = {}
 ): MermaidToExcalidrawResult => {
   switch (graph.type) {
@@ -23,6 +25,10 @@ export const graphToExcalidraw = (
 
     case "sequence": {
       return SequenceToExcalidrawSkeletonConvertor.convert(graph, options);
+    }
+
+    case "state": {
+      return StateToExcalidrawSkeletonConvertor.convert(graph, options);
     }
 
     case "class": {

--- a/src/parseMermaid.ts
+++ b/src/parseMermaid.ts
@@ -1,10 +1,11 @@
 import mermaid from "mermaid";
 import { GraphImage } from "./interfaces.js";
-import { DEFAULT_FONT_SIZE, MERMAID_CONFIG } from "./constants.js";
+import { MERMAID_CONFIG } from "./constants.js";
 import { encodeEntities } from "./utils.js";
 import { Flowchart, parseMermaidFlowChartDiagram } from "./parser/flowchart.js";
 import { Sequence, parseMermaidSequenceDiagram } from "./parser/sequence.js";
 import { Class, parseMermaidClassDiagram } from "./parser/class.js";
+import { State, parseMermaidStateDiagram } from "./parser/state.js";
 
 // Fallback to Svg
 const convertSvgToGraphImage = (svgContainer: HTMLDivElement) => {
@@ -44,7 +45,7 @@ const convertSvgToGraphImage = (svgContainer: HTMLDivElement) => {
 
 export const parseMermaid = async (
   definition: string
-): Promise<Flowchart | GraphImage | Sequence | Class> => {
+): Promise<Flowchart | GraphImage | Sequence | Class | State> => {
   mermaid.initialize(MERMAID_CONFIG);
 
   // Parse the diagram
@@ -73,6 +74,12 @@ export const parseMermaid = async (
 
     case "sequence": {
       data = parseMermaidSequenceDiagram(diagram, svgContainer);
+
+      break;
+    }
+
+    case "stateDiagram": {
+      data = parseMermaidStateDiagram(diagram, svgContainer);
 
       break;
     }

--- a/src/parser/flowchart.ts
+++ b/src/parser/flowchart.ts
@@ -1,7 +1,7 @@
 import {
   computeEdgePositions,
+  computeElementPosition,
   entityCodesToText,
-  getTransformAttr,
 } from "../utils.js";
 import {
   CONTAINER_STYLE_PROPERTY,
@@ -162,53 +162,6 @@ const parseEdge = (data: any, containerEl: Element): Edge => {
     ...edgePositionData,
     text: entityCodesToText(data.text),
   };
-};
-
-// Compute element position
-const computeElementPosition = (
-  el: Element | null,
-  containerEl: Element
-): Position => {
-  if (!el) {
-    throw new Error("Element not found");
-  }
-
-  let root = el.parentElement?.parentElement;
-
-  const childElement = el.childNodes[0] as SVGSVGElement;
-  let childPosition = { x: 0, y: 0 };
-  if (childElement) {
-    const { transformX, transformY } = getTransformAttr(childElement);
-
-    const boundingBox = childElement.getBBox();
-    childPosition = {
-      x:
-        Number(childElement.getAttribute("x")) ||
-        transformX + boundingBox.x ||
-        0,
-      y:
-        Number(childElement.getAttribute("y")) ||
-        transformY + boundingBox.y ||
-        0,
-    };
-  }
-
-  const { transformX, transformY } = getTransformAttr(el);
-  const position = {
-    x: transformX + childPosition.x,
-    y: transformY + childPosition.y,
-  };
-  while (root && root.id !== containerEl.id) {
-    if (root.classList.value === "root" && root.hasAttribute("transform")) {
-      const { transformX, transformY } = getTransformAttr(root);
-      position.x += transformX;
-      position.y += transformY;
-    }
-
-    root = root.parentElement;
-  }
-
-  return position;
 };
 
 export const parseMermaidFlowChartDiagram = (

--- a/src/parser/state.ts
+++ b/src/parser/state.ts
@@ -1,0 +1,209 @@
+import type { Diagram } from "mermaid/dist/Diagram.js";
+import {
+  createContainerSkeletonFromSVG,
+  type Node,
+} from "../elementSkeleton.js";
+import { computeEdgePositions, computeElementPosition } from "../utils.js";
+
+export interface State {
+  type: "state";
+  nodes: any[];
+  edges: any[];
+}
+
+// the names are taken from mermaidParser.lineType
+export enum LineType {
+  DOTTED_LINE = 1,
+  LINE = 0,
+}
+
+// the names are taken from mermaidParser.relationType
+export enum RelationType {
+  AGGREGATION = 0,
+  COMPOSITION = 2,
+  DEPENDENCY = 3,
+  EXTENSION = 1,
+}
+
+export interface StateNode {
+  width: number;
+  height: number;
+}
+
+export interface StateRoot {
+  [state: `state${number}`]: {
+    description: string;
+    id: string;
+    start?: boolean;
+    stmt: string;
+    type: string;
+  };
+  stmt: string;
+}
+
+const parseRelations = (data: StateRoot[], containerEl: Element) => {
+  const nodes: Array<Node> = [];
+  const parsedIds = new Set<string>();
+
+  data.forEach((state) => {
+    const state1 = state.state1;
+    const state2 = state.state2;
+
+    const relationId = [state1.id, state2.id].sort().join("-");
+
+    if (parsedIds.has(relationId)) {
+      return;
+    }
+
+    const node1 = containerEl.querySelector<SVGSVGElement>(
+      `[data-id="${state1.id}"]`
+    );
+    const node2 = containerEl.querySelector<SVGSVGElement>(
+      `[data-id="${state2.id}"]`
+    );
+
+    if (!node1 || !node2) {
+      throw new Error("State node not found");
+    }
+
+    if (!parsedIds.has(node1.id)) {
+      const node1Element = createContainerSkeletonFromSVG(
+        node1,
+        state1?.start !== undefined ? "ellipse" : "rectangle",
+        state1?.start === undefined
+          ? {
+              id: node1.id,
+              label: {
+                text: state1.description || state1.id,
+              },
+            }
+          : {
+              id: node1.id,
+              subtype: "highlight",
+            }
+      );
+
+      const node1Position = computeElementPosition(node1, containerEl);
+      node1Element.x = node1Position.x;
+      node1Element.y = node1Position.y;
+
+      if (!node1Element.bgColor && state1.start) {
+        node1Element.bgColor = "#000";
+      }
+
+      nodes.push(node1Element);
+      parsedIds.add(node1.id);
+    }
+
+    if (!parsedIds.has(node2.id)) {
+      const node2Element = createContainerSkeletonFromSVG(
+        node2,
+        state2?.start !== undefined ? "ellipse" : "rectangle",
+        state2?.start === undefined
+          ? {
+              id: node2.id,
+              label: {
+                text: state2.description || state2.id,
+              },
+            }
+          : {
+              id: node2.id,
+              groupId: node2.id,
+            }
+      );
+      const node2Position = computeElementPosition(node2, containerEl);
+
+      node2Element.x = node2Position.x;
+      node2Element.y = node2Position.y;
+
+      if (state2.id === "root_end") {
+        const innerEllipse = createContainerSkeletonFromSVG(node2, "ellipse", {
+          id: `${node2.id}-inner`,
+          groupId: node2.id,
+        });
+
+        innerEllipse.width = 4;
+        innerEllipse.height = 4;
+
+        innerEllipse.x =
+          node2Position.x + node2Element.width / 2 - innerEllipse.width / 2;
+        innerEllipse.y =
+          node2Position.y + node2Element.height / 2 - innerEllipse.height / 2;
+        innerEllipse.strokeColor = "black";
+        innerEllipse.bgColor = "black";
+
+        nodes.push(innerEllipse);
+      }
+
+      nodes.push(node2Element);
+
+      parsedIds.add(node2.id);
+    }
+  });
+
+  return nodes;
+};
+
+const parseEdges = (nodes: StateRoot[], containerEl: Element) => {
+  const edges = containerEl.querySelector(".edgePaths")?.children;
+
+  if (!edges) {
+    throw new Error("Edges not found");
+  }
+
+  return nodes.map((edge, i) => {
+    const startId = edge.state1.id;
+    const endId = edge.state2.id;
+
+    const nodeStartElement = containerEl.querySelector<SVGPathElement>(
+      `[data-id*="${startId}"]`
+    )!;
+    const nodeEndElement = containerEl.querySelector<SVGPathElement>(
+      `[data-id*="${endId}"]`
+    )!;
+
+    const edgeStartElement = edges[i] as SVGPathElement;
+
+    const position = computeElementPosition(edgeStartElement, containerEl);
+
+    const edgePositionData = computeEdgePositions(edgeStartElement, position);
+
+    return {
+      start: nodeStartElement.id,
+      end: nodeEndElement.id,
+      ...edgePositionData,
+    };
+  });
+};
+
+export const parseMermaidStateDiagram = (
+  diagram: Diagram,
+  containerEl: Element
+): State => {
+  diagram.parse();
+
+  // Get mermaid parsed data from parser shared variable `yy`
+  //@ts-ignore
+  const mermaidParser = diagram.parser.yy;
+  const nodes: Array<Node> = [];
+  const rootDocV2 = mermaidParser.getRootDocV2();
+
+  const relations = parseRelations(rootDocV2.doc, containerEl);
+
+  const edges = parseEdges(rootDocV2.doc, containerEl);
+
+  nodes.push(...relations);
+
+  console.debug({
+    nodes,
+    edges,
+    document: rootDocV2,
+    mermaidParser,
+    states: mermaidParser.getStates(),
+    relations: mermaidParser.getRelations(),
+    classes: mermaidParser.getClasses(),
+    logDocuments: mermaidParser.logDocuments(),
+  });
+
+  return { type: "state", nodes, edges };
+};

--- a/src/parser/state.ts
+++ b/src/parser/state.ts
@@ -31,6 +31,7 @@ export interface StateNode {
 }
 
 export interface StateRoot {
+  description?: string;
   [state: `state${number}`]: {
     description: string;
     id: string;
@@ -215,6 +216,9 @@ const parseEdges = (nodes: ParsedDoc[], containerEl: Element) => {
         return {
           start: nodeStartElement.id,
           end: nodeEndElement.id,
+          label: {
+            text: edge?.description,
+          },
           ...edgePositionData,
         };
       })

--- a/src/parser/state.ts
+++ b/src/parser/state.ts
@@ -481,7 +481,7 @@ const parseEdges = (nodes: ParsedDoc[], containerEl: Element): any[] => {
           const edgePositionData = computeEdgePositions(
             edgeStartElement,
             position,
-            "MC"
+            "MCL"
           );
           /**
            * Edge case where cluster don't have the .edgePaths in SVG,

--- a/src/parser/state.ts
+++ b/src/parser/state.ts
@@ -91,6 +91,8 @@ export type ParsedDoc =
   | RelationState;
 
 const MARGIN_TOP_LINE_X_AXIS = 25;
+const DEFAULT_FILL_COLOR = "rgb(236, 236, 255)";
+const DEFAULT_STROKE_COLOR = "rgb(147, 112, 219)";
 
 const isNoteState = (node: ParsedDoc): node is NoteState => {
   return "note" in node;
@@ -232,9 +234,15 @@ const createRelationExcalidrawElement = (
   groupId?: string
 ): [Container, Container | null] => {
   const shape = relation?.start !== undefined ? "ellipse" : "rectangle";
+  const styles = getComputedStyle(relationNode.firstElementChild!);
+  const haveCustomStyles = relationNode.classList.length > 3;
   const label =
     relation?.start === undefined
-      ? { label: { text: relation.description || relation.id } }
+      ? {
+          label: {
+            text: relation.description || relation.id,
+          },
+        }
       : undefined;
 
   const relationContainer = createExcalidrawElement(
@@ -245,6 +253,16 @@ const createRelationExcalidrawElement = (
   );
 
   relationContainer.groupId = groupId;
+  if (relationContainer.label) {
+    relationContainer.label.color = styles.color;
+  }
+
+  if (typeof relation.start === "undefined" && haveCustomStyles) {
+    relationContainer.strokeColor =
+      styles.stroke === DEFAULT_STROKE_COLOR ? "#000" : styles.stroke;
+    relationContainer.bgColor =
+      styles.fill === DEFAULT_FILL_COLOR ? undefined : styles.fill;
+  }
 
   if (relation?.start) {
     relationContainer.bgColor = "#000";

--- a/src/parser/state.ts
+++ b/src/parser/state.ts
@@ -3,7 +3,11 @@ import {
   createContainerSkeletonFromSVG,
   type Node,
 } from "../elementSkeleton.js";
-import { computeEdgePositions, computeElementPosition } from "../utils.js";
+import {
+  computeEdge2Positions,
+  computeEdgePositions,
+  computeElementPosition,
+} from "../utils.js";
 
 export interface State {
   type: "state";
@@ -61,7 +65,7 @@ const parseRelations = (data: ParsedDoc[], containerEl: Element) => {
     if (isSingleState) {
       const node1 = containerEl.querySelector<SVGSVGElement>(
         `[data-id="${state.id}"]`
-      );
+      )!;
 
       const node1Position = computeElementPosition(node1, containerEl);
 
@@ -165,9 +169,13 @@ const parseRelations = (data: ParsedDoc[], containerEl: Element) => {
         innerEllipse.height = 4;
 
         innerEllipse.x =
-          node2Position.x + node2Element.width / 2 - innerEllipse.width / 2;
+          node2Position.x +
+          (node2Element.width as number) / 2 -
+          innerEllipse.width / 2;
         innerEllipse.y =
-          node2Position.y + node2Element.height / 2 - innerEllipse.height / 2;
+          node2Position.y +
+          (node2Element.height as number) / 2 -
+          innerEllipse.height / 2;
         innerEllipse.strokeColor = "black";
         innerEllipse.bgColor = "black";
 
@@ -208,7 +216,7 @@ const parseEdges = (nodes: ParsedDoc[], containerEl: Element) => {
         const edgeStartElement = edges[i] as SVGPathElement;
 
         const position = computeElementPosition(edgeStartElement, containerEl);
-        const edgePositionData = computeEdgePositions(
+        const edgePositionData = computeEdge2Positions(
           edgeStartElement,
           position
         );

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -113,17 +113,22 @@ export const computeEdgePositions = (
         .map((coord) => parseFloat(coord));
 
       if (commandType === "C") {
-        // For other "C" commands, return the end point
-        return { x: coords[4], y: coords[5] };
+        return { x: coords[4], y: coords[5], command: commandType };
       }
 
-      return { x: coords[0], y: coords[1] };
+      return { x: coords[0], y: coords[1], command: commandType };
     })
     .filter((point, index, array) => {
       // Always include the last point
       if (index === array.length - 1) {
         return true;
       }
+
+      // Exclude the second last point if it's a "C" command because this is a curve and the last point is the end point, so we don't need to include it.
+      if (index === array.length - 2 && point.command === "C") {
+        return false;
+      }
+
       // Include the start point or if the current point if it's not the same as the previous point
       const prevPoint = array[index - 1];
       return (

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -70,7 +70,8 @@ interface EdgePositionData {
 // Compute edge postion start, end and points (reflection points)
 export const computeEdgePositions = (
   pathElement: SVGPathElement,
-  offset: Position = { x: 0, y: 0 }
+  offset: Position = { x: 0, y: 0 },
+  commandsPattern = "LM"
 ): EdgePositionData => {
   // Check if the element is a path else throw an error
   if (pathElement.tagName.toLowerCase() !== "path") {
@@ -85,82 +86,9 @@ export const computeEdgePositions = (
     throw new Error('Path element does not contain a "d" attribute');
   }
 
-  // Split the d attribute based on M (Move To) and L (Line To) commands
-  // eg "M29.383,38.5L29.383,63.5L29.383,83.2" => ["M29.383,38.5", "L29.383,63.5", "L29.383,83.2"]
-  const commands = dAttr.split(/(?=[LM])/);
-
-  // Get the start position from the first commands element => [29.383,38.5]
-  const startPosition = commands[0]
-    .substring(1)
-    .split(",")
-    .map((coord) => parseFloat(coord));
-
-  // Get the last position from the last commands element => [29.383,83.2]
-  const endPosition = commands[commands.length - 1]
-    .substring(1)
-    .split(",")
-    .map((coord) => parseFloat(coord));
-
-  // compute the reflection points -> [ {x: 29.383, y: 38.5}, {x: 29.383, y: 83.2} ]
-  // These includes the start and end points and also points which are not the same as the previous points
-  const reflectionPoints = commands
-    .map((command) => {
-      const coords = command
-        .substring(1)
-        .split(",")
-        .map((coord) => parseFloat(coord));
-
-      return { x: coords[0], y: coords[1] };
-    })
-    .filter((point, index, array) => {
-      // Always include the last point
-      if (index === array.length - 1) {
-        return true;
-      }
-      // Include the start point or if the current point if it's not the same as the previous point
-      const prevPoint = array[index - 1];
-      return (
-        index === 0 || (point.x !== prevPoint.x && point.y !== prevPoint.y)
-      );
-    })
-    .map((p) => {
-      // Offset the point by the provided offset
-      return {
-        x: p.x + offset.x,
-        y: p.y + offset.y,
-      };
-    });
-
-  // Return the edge positions
-  return {
-    startX: startPosition[0] + offset.x,
-    startY: startPosition[1] + offset.y,
-    endX: endPosition[0] + offset.x,
-    endY: endPosition[1] + offset.y,
-    reflectionPoints,
-  };
-};
-
-export const computeEdge2Positions = (
-  pathElement: SVGPathElement,
-  offset: Position = { x: 0, y: 0 }
-): EdgePositionData => {
-  // Check if the element is a path else throw an error
-  if (pathElement.tagName.toLowerCase() !== "path") {
-    throw new Error(
-      `Invalid input: Expected an HTMLElement of tag "path", got ${pathElement.tagName}`
-    );
-  }
-
-  // Get the d attribute from the path element else throw an error
-  const dAttr = pathElement.getAttribute("d");
-  if (!dAttr) {
-    throw new Error('Path element does not contain a "d" attribute');
-  }
-
-  // Split the d attribute based on M (Move To) and L (Line To) commands
-  // eg "M29.383,38.5L29.383,63.5L29.383,83.2" => ["M29.383,38.5", "L29.383,63.5", "L29.383,83.2"]
-  const commands = dAttr.split(/(?=[MC])/);
+  // Split the d attribute based on some commands: M (Move To), L (Line To) commands and if specifies C (Curve To) commands
+  // eg "M29.383,38.5L29.383,63.5L29.383,83.2" => ["M29.383,38.5", "L29.383,63.5", "L29.383,83.2", "C29.383,83.2"]
+  const commands = dAttr.split(new RegExp(`(?=[${commandsPattern}])`));
 
   // Get the start position from the first commands element => [29.383,38.5]
   const startPosition = commands[0]

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -138,3 +138,50 @@ export const computeEdgePositions = (
     reflectionPoints,
   };
 };
+
+// Compute element position
+export const computeElementPosition = (
+  el: Element | null,
+  containerEl: Element
+): Position => {
+  if (!el) {
+    throw new Error("Element not found");
+  }
+
+  let root = el.parentElement?.parentElement;
+
+  const childElement = el.childNodes[0] as SVGSVGElement;
+  let childPosition = { x: 0, y: 0 };
+  if (childElement) {
+    const { transformX, transformY } = getTransformAttr(childElement);
+
+    const boundingBox = childElement.getBBox();
+    childPosition = {
+      x:
+        Number(childElement.getAttribute("x")) ||
+        transformX + boundingBox.x ||
+        0,
+      y:
+        Number(childElement.getAttribute("y")) ||
+        transformY + boundingBox.y ||
+        0,
+    };
+  }
+
+  const { transformX, transformY } = getTransformAttr(el);
+  const position = {
+    x: transformX + childPosition.x,
+    y: transformY + childPosition.y,
+  };
+  while (root && root.id !== containerEl.id) {
+    if (root.classList.value === "root" && root.hasAttribute("transform")) {
+      const { transformX, transformY } = getTransformAttr(root);
+      position.x += transformX;
+      position.y += transformY;
+    }
+
+    root = root.parentElement;
+  }
+
+  return position;
+};


### PR DESCRIPTION
## Basic example:

<img width="1374" alt="Captura de Tela 2024-04-27 às 19 56 27" src="https://github.com/excalidraw/mermaid-to-excalidraw/assets/54173994/f85f6206-bc54-4357-bab0-802ea062b96d">

## Todo

- [x] Support a single state
- [x] Support a transition
- [x] Support a text transition
- [x] Support start and end syntax
   - [x] Working end-inner ellipse not stays in the same groupId as end state
- [x] Support composite states
	- [x] Working in group id when have nested layers - need to ask how to deep nested layers in groupIds (currently only bound for current cluster)
	- [x] Maybe we bind the edges incorrectly when is a parent (https://github.com/mermaid-js/mermaid/pull/5503)
- [x] Support choice
   - [x] Inside a composite state 
- [x] Support forks
- [x] Support notes
   - [x] working minor fixes when inside a composite state 🔧 
   - [ ] currently edges for a note is wrong because we don't have from, to ID. maybe we should wait mermaid release https://github.com/mermaid-js/mermaid/pull/5503 or try a workaround
- [x] Support concurrency
   - [x] maybe a minor adjusts in arrow label 🔧
- [x] Support specify a direction
    - [ ] in some cases edge is not found, this will resolve: https://github.com/mermaid-js/mermaid/pull/5503 or try a workaround
- [x] Support styling
- [ ] Refactor current code. In the current stage, the focus is mainly on making things work, and I haven't thought much about how to have things in a better way.
