### PR TITLE
fix: only consider edges which are present in DOM for flowchart

### DIFF
--- a/playground/testcases/flowchart.ts
+++ b/playground/testcases/flowchart.ts
@@ -468,4 +468,17 @@ C -->|Two| E[Result two]
 `,
     type: "flowchart",
   },
+  {
+    name: "When some edges aren't present in DOM",
+    definition: `flowchart TB   
+    subgraph conference
+        frontend
+        backend
+        security
+    end
+    frontend --> |Dive into frontend frameworks| conference
+    backend --> |Learn all about backend| conference
+    security --> |securing web apps| conference`,
+    type: "flowchart",
+  },
 ];

--- a/src/parser/flowchart.ts
+++ b/src/parser/flowchart.ts
@@ -11,7 +11,7 @@ import {
   Vertex,
 } from "../interfaces.js";
 
-import { Diagram } from "mermaid/dist/Diagram.js";
+import type { Diagram } from "mermaid/dist/Diagram.js";
 
 export interface Flowchart {
   type: "flowchart";

--- a/src/parser/flowchart.ts
+++ b/src/parser/flowchart.ts
@@ -231,7 +231,7 @@ export const parseMermaidFlowChartDiagram = (
   const edges = mermaidParser
     .getEdges()
     .filter((edge: any) => {
-      // Sometimes mermaid parser returns edges which are not present in the DOM hence this is a safety check to only consider edges present in the DOM
+      // Sometimes mermaid parser returns edges which are not present in the DOM hence this is a safety check to only consider edges present in the DOM, issue - https://github.com/mermaid-js/mermaid/issues/5516
       return containerEl.querySelector(`[id*="L-${edge.start}-${edge.end}"]`);
     })
     .map((edge: any) => parseEdge(edge, containerEl));

--- a/src/parser/flowchart.ts
+++ b/src/parser/flowchart.ts
@@ -230,7 +230,12 @@ export const parseMermaidFlowChartDiagram = (
   });
   const edges = mermaidParser
     .getEdges()
-    .map((data: any) => parseEdge(data, containerEl));
+    .filter((edge: any) => {
+      // Sometimes mermaid parser returns edges which are not present in the DOM hence this is a safety check to only consider edges present in the DOM
+      return containerEl.querySelector(`[id*="L-${edge.start}-${edge.end}"]`);
+    })
+    .map((edge: any) => parseEdge(edge, containerEl));
+
   const subGraphs = mermaidParser
     .getSubGraphs()
     .map((data: any) => parseSubGraph(data, containerEl));


### PR DESCRIPTION
Sometime mermaid db `getEdges` function returns `edges` which aren't present in the DOM hence I am filtering the edges to consider only which are present in DOM. I have created an [issue](https://github.com/mermaid-js/mermaid/issues/5516) in mermaid as well for the same, will try to fix this in mermaid library itself. 

```
flowchart TB   
    subgraph conference
        frontend
        backend
        security
    end
    frontend --> |Dive into frontend frameworks| conference
    backend --> |Learn all about backend| conference
    security --> |securing web apps| conference
```