### PR TITLE
feat: support classDef for styling nodes in flowchart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+### Features
+
+- Support ClassDef for styling the nodes by [@ad1992](https://github.com/ad1992) in https://github.com/excalidraw/mermaid-to-excalidraw/pull/71
+
 ## v1.1.0 (2024-07-10)
 
 ## Library

--- a/playground/testcases/flowchart.ts
+++ b/playground/testcases/flowchart.ts
@@ -361,6 +361,15 @@ style id2 fill:#bbf,stroke:#f66,stroke-width:2px,color:#fff,stroke-dasharray: 5 
     type: "flowchart",
   },
   {
+    name: "Styling a node using class",
+    definition: `flowchart LR
+    A:::foo & B:::bar --> C:::foobar
+    classDef foo stroke:#1971c2, fill:#4dabf7
+    classDef bar stroke:#d6336c, fill:#f783ac
+    classDef foobar stroke:#00f stroke-width:2px`,
+    type: "flowchart",
+  },
+  {
     name: "Classes",
     definition: `flowchart LR
 A-->B[AAABBB]


### PR DESCRIPTION
```
flowchart LR
    A:::foo & B:::bar --> C:::foobar
    classDef foo stroke:#1971c2, fill:#4dabf7,
    classDef bar stroke:#d6336c, fill:#f783ac
    classDef foobar stroke:#00f stroke-width:2px
```

![image](https://github.com/user-attachments/assets/6bc252a7-9622-468b-b4f7-d150e2fc7cdf)

closes https://github.com/excalidraw/mermaid-to-excalidraw/issues/69