### PR TITLE
Persist mermaid editor state using localStorage

### DIFF
--- a/playground/CustomTest.tsx
+++ b/playground/CustomTest.tsx
@@ -32,6 +32,7 @@ const CustomTest = ({
           rows={10}
           cols={50}
           name="mermaid-input"
+          value={mermaidData.definition}
           onChange={(e) => {
             if (!isActive) {
               return;

--- a/playground/index.tsx
+++ b/playground/index.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useDeferredValue } from "react";
+import { useState, useCallback, useDeferredValue, useEffect } from "react";
 import CustomTest from "./CustomTest.tsx";
 import ExcalidrawWrapper from "./ExcalidrawWrapper.tsx";
 import Testcases from "./Testcases.tsx";
@@ -14,15 +14,28 @@ export interface MermaidData {
 
 export type ActiveTestCaseIndex = number | "custom" | null;
 
+const STORAGE_KEY = "mermaid-data";
+
+const getInitialMermaidData = (): MermaidData => {
+  const saved = localStorage.getItem(STORAGE_KEY);
+  return saved
+    ? JSON.parse(saved)
+    : {
+      definition: "graph TD;\nA-->B;",
+      error: null,
+      output: null,
+    };
+};
+
 const App = () => {
-  const [mermaidData, setMermaidData] = useState<MermaidData>({
-    definition: "",
-    error: null,
-    output: null,
-  });
+  const [mermaidData, setMermaidData] = useState<MermaidData>(getInitialMermaidData);
+
+  useEffect(() => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(mermaidData));
+  }, [mermaidData]);
 
   const [activeTestCaseIndex, setActiveTestCaseIndex] =
-    useState<ActiveTestCaseIndex>(null);
+    useState<ActiveTestCaseIndex>("custom");
   const deferredMermaidData = useDeferredValue(mermaidData);
 
   const handleOnChange = useCallback(


### PR DESCRIPTION
### Summary
- Added `STORAGE_KEY = "mermaid-data"` constant to manage persistence.
- Implemented `getInitialMermaidData()` to restore the last used mermaid definition, error, and output from localStorage.
- Updated `App` component to:
  - Initialize state from localStorage (or fallback to a default definition).
  - Sync mermaid data back to localStorage whenever it changes.

### Why
Previously, all edits in the mermaid editor were lost on page refresh.  
This change ensures that users can continue from where they left off without retyping their diagram definition.

Closes #70